### PR TITLE
Improved L-stats API

### DIFF
--- a/lmo/_lm.py
+++ b/lmo/_lm.py
@@ -22,7 +22,13 @@ import numpy as np
 import numpy.typing as npt
 
 from . import ostats, pwm_beta
-from ._utils import clean_order, ensure_axis_at, moments_to_ratio, ordered
+from ._utils import (
+    clean_order,
+    ensure_axis_at,
+    l_stats_orders,
+    moments_to_ratio,
+    ordered,
+)
 from .linalg import ir_pascal, sandwich, sh_legendre, trim_matrix
 from .typing import AnyInt, IntVector, LMomentOptions, SortKind
 
@@ -760,6 +766,7 @@ def l_stats(
     a: npt.ArrayLike,
     /,
     trim: tuple[float, float] = (0, 0),
+    num: int = 4,
     *,
     axis: int | None = None,
     dtype: np.dtype[T] | type[T] = np.float_,
@@ -768,7 +775,8 @@ def l_stats(
     """
     Calculates the L-loc(ation), L-scale, L-skew(ness) and L-kurtosis.
 
-    Equivalent to `lmo.l_ratio(a, [1, 2, 3, 4], [0, 0, 2, 2], *, **)`.
+    Equivalent to `lmo.l_ratio(a, [1, 2, 3, 4], [0, 0, 2, 2], *, **)` by
+    default.
 
     Examples:
         >>> import lmo, scipy.stats
@@ -784,7 +792,7 @@ def l_stats(
         - [`lmo.l_ratio`][lmo.l_ratio]
         - [`lmo.l_costats`][lmo.l_costats]
     """
-    r, s = [1, 2, 3, 4], [0, 0, 2, 2]
+    r, s = l_stats_orders(num)
     return l_ratio(a, r, s, trim=trim, axis=axis, dtype=dtype, **kwargs)
 
 
@@ -792,6 +800,7 @@ def l_stats_se(
     a: npt.ArrayLike,
     /,
     trim: tuple[int, int] = (0, 0),
+    num: int = 4,
     *,
     axis: int | None = None,
     dtype: np.dtype[T] | type[T] = np.float_,
@@ -800,7 +809,8 @@ def l_stats_se(
     """
     Calculates the standard errors (SE's) of the [`L-stats`][lmo.l_stats].
 
-    Equivalent to `lmo.l_ratio_se(a, [1, 2, 3, 4], [0, 0, 2, 2], *, **)`.
+    Equivalent to `lmo.l_ratio_se(a, [1, 2, 3, 4], [0, 0, 2, 2], *, **)` by
+    default.
 
     Examples:
         >>> import lmo, scipy.stats
@@ -818,7 +828,7 @@ def l_stats_se(
         - [`lmo.l_stats`][lmo.l_stats]
         - [`lmo.l_ratio_se`][lmo.l_ratio_se]
     """
-    r, s = [1, 2, 3, 4], [0, 0, 2, 2]
+    r, s = l_stats_orders(num)
     return l_ratio_se(a, r, s, trim=trim, axis=axis, dtype=dtype, **kwargs)
 
 

--- a/lmo/_utils.py
+++ b/lmo/_utils.py
@@ -6,6 +6,7 @@ __all__ = (
     'clean_orders',
     'clean_trim',
     'moments_to_ratio',
+    'l_stats_orders',
 )
 
 from typing import Any, SupportsIndex, TypeVar
@@ -236,3 +237,13 @@ def moments_to_ratio(
             np.ones_like(l_rs[0]),
             np.divide(l_rs[0], l_rs[1], where=~r_eq_s),
         )[()]
+
+
+def l_stats_orders(
+    num: int,
+    /,
+) -> tuple[npt.NDArray[np.int_], npt.NDArray[np.int_]]:
+    return (
+        np.arange(1, num + 1),
+        np.array([0] * min(2, num) + [2] * (num - 2)),
+    )

--- a/lmo/theoretical.py
+++ b/lmo/theoretical.py
@@ -832,8 +832,8 @@ def l_ratio_from_rv(
 def l_stats_from_cdf(
     cdf: Callable[[float], float],
     /,
-    num: int = 4,
     trim: AnyTrim = (0, 0),
+    num: int = 4,
     *,
     support: tuple[AnyFloat, AnyFloat] = (-np.inf, np.inf),
     **kwargs: Any,

--- a/lmo/theoretical.py
+++ b/lmo/theoretical.py
@@ -32,7 +32,7 @@ import scipy.special as scs  # type: ignore
 from scipy.stats.distributions import rv_continuous, rv_frozen  # type: ignore
 
 from . import _poly
-from ._utils import clean_order, clean_trim, moments_to_ratio
+from ._utils import clean_order, clean_trim, l_stats_orders, moments_to_ratio
 from .linalg import sh_jacobi
 from .typing import AnyFloat, AnyInt, AnyTrim, IntVector
 
@@ -829,16 +829,6 @@ def l_ratio_from_rv(
 
     return moments_to_ratio(rs, l_rs)
 
-
-def _l_stats_orders(
-    num: int,
-) -> tuple[npt.NDArray[np.int_], npt.NDArray[np.int_]]:
-    return (
-        np.arange(1, num + 1),
-        np.array([0] * min(2, num) + [2] * (num - 2)),
-    )
-
-
 def l_stats_from_cdf(
     cdf: Callable[[float], float],
     /,
@@ -874,15 +864,15 @@ def l_stats_from_cdf(
         - [`lmo.l_stats`][lmo.l_stats] - Unbiased sample estimation of L-stats.
 
     """
-    r, s = _l_stats_orders(num)
+    r, s = l_stats_orders(num)
     return l_ratio_from_cdf(cdf, r, s, trim, support=support, **kwargs)
 
 
 def l_stats_from_ppf(
     ppf: Callable[[float], float],
     /,
-    num: int = 4,
     trim: AnyTrim = (0, 0),
+    num: int = 4,
     *,
     support: tuple[AnyFloat, AnyFloat] = (0, 1),
     **kwargs: Any,
@@ -912,15 +902,15 @@ def l_stats_from_ppf(
             population L-ratio's from the quantile function.
         - [`lmo.l_stats`][lmo.l_stats] - Unbiased sample estimation of L-stats.
     """
-    r, s = _l_stats_orders(num)
+    r, s = l_stats_orders(num)
     return l_ratio_from_ppf(ppf, r, s, trim, support=support, **kwargs)
 
 
 def l_stats_from_rv(
     rv: rv_continuous | rv_frozen,
     /,
-    num: int = 4,
     trim: AnyTrim = (0, 0),
+    num: int = 4,
     *rv_args: Any,
     rtol: float = DEFAULT_RTOL,
     atol: float = DEFAULT_ATOL,
@@ -964,7 +954,7 @@ def l_stats_from_rv(
         - [`l_ratio_from_rv`][lmo.theoretical.l_ratio_from_ppf]
         - [`lmo.l_stats`][lmo.l_stats] - Unbiased sample estimation of L-stats.
     """
-    r, s = _l_stats_orders(num)
+    r, s = l_stats_orders(num)
     return l_ratio_from_rv(
         rv,
         r,


### PR DESCRIPTION
- Added the optional `num: int = 4` argument to `lmo.l_stats` and `lmo.l_stats_se`
- Re-ordered the `num` param to come after `trim` in `lmo.theoretical.l_stats_from_(cdf|ppf|rv)`, making it consistent with the `lmo.l_stats(_se)?` methods.