### PR TITLE
Theoretical influence functions & robustness measures

### DIFF
--- a/lmo/_lm.py
+++ b/lmo/_lm.py
@@ -667,9 +667,20 @@ def l_ratio(
 
     Equivalent to `lmo.l_moment(a, r, *, **) / lmo.l_moment(a, s, *, **)`.
 
+    The L-moment with `r=0` is `1`, so the `l_ratio(a, r, 0, *, **)` is
+    equivalent to `l_moment(a, r, *, **)`.
+
     Notes:
-        The L-moment with `r=0` is `1`, so the `l_ratio(a, r, 0, *, **)` is
-        equivalent to `l_moment(a, r, *, **)`
+        Often, when referring to the $r$th *L-ratio*, the L-moment ratio with
+        $k=2$ is implied, i.e. $\tau^{(s, t)}_r$ is short-hand notation
+        for $\tau^{(s, t)}_{r,2}$.
+
+        The L-variation (L-moment Coefficient of Variation, or L-CB) is
+        another special case of the L-moment ratio, $\tau^{(s, t)}_{2,1}$.
+        It is sometimes denoted in the literature by dropping the subscript
+        indices: $\tau^{(s, t)}$.
+        Note that this should only be used with strictly positive
+        distributions.
 
     Examples:
         Estimate the L-location, L-scale, L-skewness and L-kurtosis

--- a/lmo/_utils.py
+++ b/lmo/_utils.py
@@ -63,7 +63,7 @@ def as_float_array(
 
 def round0(a: npt.NDArray[T], /, tol: float = 1e-8) -> npt.NDArray[T]:
     """Round values close to zero."""
-    return np.where(np.abs(a) <= tol, 0, a)
+    return np.where(np.abs(a) <= abs(tol), 0, a) if tol else a
 
 
 def _apply_aweights(

--- a/lmo/diagnostic.py
+++ b/lmo/diagnostic.py
@@ -575,7 +575,7 @@ def rejection_point(
     \right\} \;
     $$
 
-    with a $\epsilon$ a small positive number, correspoding to the `tol` param
+    with a $\epsilon$ a small positive number, corresponding to the `tol` param
     of e.g. `lmo.theoretical.l_moment_influence`, which defaults to `1e-8`.
 
     Examples:
@@ -721,6 +721,3 @@ def error_sensitivity(
         raise RuntimeError(res.message)  # type: ignore
 
     return -cast(float, res.fun)  # type: ignore
-
-
-# TODO: IF Local-shift sensitivty

--- a/lmo/diagnostic.py
+++ b/lmo/diagnostic.py
@@ -675,6 +675,21 @@ def error_sensitivity(
     \gamma^*_{T|F} = \max_{x} \left| \psi_{T|F}(x) \right|
     $$
 
+    Examples:
+        Evaluate the gross-error sensitivity of the standard exponential
+        distribution's LL-skewness ($\tau^{(0, 1)}_3$) and LL-kurtosis
+        ($\tau^{(0, 1)}_4$) coefficients:
+
+        >>> from lmo.diagnostic import error_sensitivity
+        >>> from lmo.theoretical import l_ratio_influence
+        >>> from scipy.stats import expon
+        >>> ll_skew_if = l_ratio_influence(expon, 3, trim=(0, 1))
+        >>> ll_kurt_if = l_ratio_influence(expon, 4, trim=(0, 1))
+        >>> error_sensitivity(ll_skew_if, domain=(0, float('inf')))
+        1.17288889...
+        >>> error_sensitivity(ll_kurt_if, domain=(0, float('inf')))
+        1.37774354...
+
     Args:
         influence_fn: The influence function.
         domain: Domain of the CDF. Defaults to $(-\infty, \infty)$.

--- a/lmo/diagnostic.py
+++ b/lmo/diagnostic.py
@@ -15,6 +15,8 @@ from typing import Any, NamedTuple, TypeVar, cast, overload
 
 import numpy as np
 import numpy.typing as npt
+from scipy.integrate import quad  # type: ignore
+from scipy.optimize import OptimizeResult, minimize  # type: ignore
 from scipy.special import chdtrc  # type: ignore
 from scipy.stats.distributions import rv_continuous, rv_frozen  # type: ignore
 
@@ -551,3 +553,96 @@ def l_ratio_bounds(
             out[_k] = out[_k - 1] * (1 + p / _k) / (1 + q / (_k - 1))
 
     return out[_r]
+
+
+def rejection_point(
+    influence_fn: Callable[[npt.ArrayLike], float | npt.NDArray[np.float_]],
+    /,
+    rho_min: float = 0,
+    rho_max: float = np.inf,
+) -> float:
+    r"""
+    Evaluate the approximate *rejection point* of an influence function
+    $\psi_{T|F}(x)$ given a *statistical functional* $T$ (e.g. an L-moment)
+    and cumulative distribution function $F(x)$.
+
+    $$
+    \rho^*_{T|F} = \inf_{r>0} \left\{
+        r: | \psi_{T|F}(x) | \le \epsilon, \, |x| > r
+    \right\} \;
+    $$
+
+    with a $\epsilon$ a small positive number, correspoding to the `tol` param
+    of e.g. `lmo.theoretical.l_moment_influence`, which defaults to `1e-8`.
+
+    Examples:
+        The untrimmed L-location isn't robust, e.g. with the standard normal
+        distribution:
+
+        >>> import numpy as np
+        >>> from scipy.stats import distributions as dists
+        >>> from lmo.diagnostic import rejection_point
+        >>> from lmo.theoretical import l_moment_influence
+        >>> if_l_loc_norm = l_moment_influence(dists.norm, 1, trim=0)
+        >>> if_l_loc_norm(np.inf)
+        inf
+        >>> rejection_point(if_l_loc_norm)
+        nan
+
+        For the TL-location of the Gaussian distribution, and even for the
+        Student's t distribution with 4 degrees of freedom (3 also works, but
+        is very slow), they exist.
+
+        >>> if_tl_loc_norm = l_moment_influence(dists.norm, 1, trim=1)
+        >>> if_tl_loc_t4 = l_moment_influence(dists.t(4), 1, trim=1)
+        >>> if_tl_loc_norm(np.inf), if_tl_loc_t4(np.inf)
+        (0.0, 0.0)
+        >>> rejection_point(if_tl_loc_norm), rejection_point(if_tl_loc_t4)
+        (6.0, 206.0)
+
+    Notes:
+        Large rejection points (e.g. >1000) are unlikely to be found.
+
+        For instance, that of the TL-location of the Student's t distribution
+        with 2 degrees of freedom lies between somewhere `1e4` and `1e5`, but
+        will not be found. In this case, using `trim=2` will return `166.0`.
+
+    See Also:
+        - [`l_moment_influence`][lmo.theoretical.l_moment_influence]
+        - [`l_ratio_influence`][lmo.theoretical.l_ratio_influence]
+    """
+    if not 0 <= rho_min < rho_max:
+        msg = f'expected 0 <= rho_min < rho_max, got {rho_min=} and {rho_max=}'
+        raise ValueError(msg)
+    if rho_min != 0 and np.all(influence_fn([-rho_min, rho_min]) == 0):
+        msg = 'expected influence_fn(r) != 0 for r in [-rho_min, rho_min]'
+        raise ValueError(msg)
+
+    if not np.all(influence_fn([-rho_max, rho_max]) == 0):
+        return np.nan
+
+    def integrand(x: float) -> float:
+        return np.abs(influence_fn([-x, x])).max()
+
+    def obj(r: npt.NDArray[np.float_]) -> float:
+        return quad(integrand, r[0], np.inf)[0]  # type: ignore
+
+    res = cast(
+        OptimizeResult,
+        minimize(
+            obj,
+            bounds=[(rho_min, rho_max)],
+            x0=[rho_min],
+            method='COBYLA',
+        ),
+    )
+
+    rho = cast(float, res.x[0])  # type: ignore
+    if rho <= 1e-5 or np.any(influence_fn([-rho, rho])):
+        return np.nan
+
+    return rho
+
+
+# TODO: IF Gross-error sensitivity
+# TODO: IF Local-shift sensitivty

--- a/lmo/theoretical.py
+++ b/lmo/theoretical.py
@@ -1535,6 +1535,12 @@ def l_moment_influence(
     Returns:
         influence_function:
             The influence function, with vectorized signature `() -> ()`.
+
+    See Also:
+        - [`l_ratio_influence`][lmo.theoretical.l_ratio_influence]
+        - [`l_moment_from_cdf`][lmo.theoretical.l_moment_from_cdf]
+        - [`l_moment_from_rv`][lmo.theoretical.l_moment_from_rv]
+        - [`lmo.l_moment`][lmo.l_moment]
     """
     _r = clean_order(r)
     if _r == 0:
@@ -1628,7 +1634,7 @@ def l_ratio_influence(
         \lambda^{(s, t)}_r
     }{
         \lambda^{(s, t)}_k
-    } ;.
+    } \;.
     $$
 
     Because IF's are a special case of the general Gâteuax derivative, the
@@ -1655,6 +1661,12 @@ def l_ratio_influence(
     Returns:
         influence_function:
             The influence function, with vectorized signature `() -> ()`.
+
+    See Also:
+        - [`l_moment_influence`][lmo.theoretical.l_moment_influence]
+        - [`l_ratio_from_cdf`][lmo.theoretical.l_ratio_from_cdf]
+        - [`l_ratio_from_rv`][lmo.theoretical.l_ratio_from_rv]
+        - [`lmo.l_ratio`][lmo.l_ratio]
 
     """
     _r, _k = clean_order(r), clean_order(k)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,6 @@ theme:
   font:
     text: Fira Sans
     code: Fira Mono
-  custom_dir: docs/jinja
 
 extra:
   social:


### PR DESCRIPTION
Added:

- `theoretical.l_moment_influence`
- `theoretical.l_ratio_influence`

which can be used in:

- `diagnostic.rejection_point`
- `diagnostic.error_sensitivity`
- `diagnostic.shift_sensitivity`