### PR TITLE
Add theoretical L-* methods to all `scipy.stats` univariate distributions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12.0-rc.1']
+        python-version: ['3.10', '3.11', '3.12.0-rc.2']
 
     steps:
       - name: checkout

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,8 +27,13 @@
     options:
       members:
       - l_rv_generic
-      - l_rv_frozen
       - l_rv_nonparametric
+      heading_level: 4
+
+### Statistical test and tools 
+
+::: lmo.diagnostic
+    options:
       heading_level: 4
 
 ## Low-level API
@@ -39,20 +44,11 @@
       - l_weights
       heading_level: 3
 
-
-### Theoretical L-moments
+### `theoretical`
 
 ::: lmo.theoretical
     options:
       heading_level: 4
-
-
-### Statistical test and tools 
-
-::: lmo.diagnostic
-    options:
-      heading_level: 4
-
 
 ### `linalg`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -10,15 +10,8 @@
       filters: 
       - "!l_weights"
       - "!^l_co"
+      - "!^l_rv"
       heading_level: 4
-
-
-### Population L-moments
-
-::: lmo.theoretical
-    options:
-      heading_level: 4
-
 
 ### Sample L-comoments
 
@@ -28,12 +21,15 @@
       heading_level: 4
 
 
-### Statistical test and tools 
+### Distributions
 
-::: lmo.diagnostic
+::: lmo
     options:
+      members:
+      - l_rv_generic
+      - l_rv_frozen
+      - l_rv_nonparametric
       heading_level: 4
-
 
 ## Low-level API
 
@@ -42,6 +38,20 @@
       members:
       - l_weights
       heading_level: 3
+
+
+### Theoretical L-moments
+
+::: lmo.theoretical
+    options:
+      heading_level: 4
+
+
+### Statistical test and tools 
+
+::: lmo.diagnostic
+    options:
+      heading_level: 4
 
 
 ### `linalg`

--- a/lmo/__init__.py
+++ b/lmo/__init__.py
@@ -22,12 +22,12 @@ __all__ = (
     'l_corr',
     'l_coskew',
     'l_cokurtosis',
-    'l_rv',
+    'l_sample_rv',
 )
 
 from typing import Final as _Final
 
-from ._distns import l_rv
+from ._distns import l_sample_rv
 from ._lm import (
     l_kurtosis,
     l_loc,

--- a/lmo/__init__.py
+++ b/lmo/__init__.py
@@ -22,12 +22,17 @@ __all__ = (
     'l_corr',
     'l_coskew',
     'l_cokurtosis',
-    'l_sample_rv',
+
+    'l_rv_nonparametric',
+    'l_rv_generic',
 )
 
 from typing import Final as _Final
 
-from ._distns import l_sample_rv
+from ._distns import (
+    l_rv_generic,
+    l_rv_nonparametric,
+)
 from ._lm import (
     l_kurtosis,
     l_loc,

--- a/lmo/__init__.py
+++ b/lmo/__init__.py
@@ -27,16 +27,10 @@ __all__ = (
     'l_rv',
 )
 
-from typing import (
-    TYPE_CHECKING as _TYPE_CHECKING,
-    Final as _Final,
-)
+from typing import Final as _Final
 
 from . import theoretical
-from ._distns import (
-    l_rv,
-    patch_rv as _patch_rv,
-)
+from ._distns import l_rv
 from ._lm import (
     l_kurtosis,
     l_loc,
@@ -64,6 +58,3 @@ from ._lm_co import (
 from ._meta import get_version as _get_version
 
 __version__: _Final[str] = _get_version()
-
-if not _TYPE_CHECKING:
-    _patch_rv()

--- a/lmo/__init__.py
+++ b/lmo/__init__.py
@@ -2,8 +2,6 @@
 __all__ = (
     '__version__',
 
-    'theoretical',
-
     'l_weights',
     'l_moment',
     'l_moment_cov',
@@ -29,7 +27,6 @@ __all__ = (
 
 from typing import Final as _Final
 
-from . import theoretical
 from ._distns import l_rv
 from ._lm import (
     l_kurtosis,

--- a/lmo/__init__.py
+++ b/lmo/__init__.py
@@ -1,6 +1,9 @@
 # noqa: D104
 __all__ = (
     '__version__',
+
+    'theoretical',
+
     'l_weights',
     'l_moment',
     'l_moment_cov',
@@ -24,9 +27,16 @@ __all__ = (
     'l_rv',
 )
 
-from typing import Final as _Final
+from typing import (
+    TYPE_CHECKING as _TYPE_CHECKING,
+    Final as _Final,
+)
 
-from ._distns import l_rv
+from . import theoretical
+from ._distns import (
+    l_rv,
+    patch_rv as _patch_rv,
+)
 from ._lm import (
     l_kurtosis,
     l_loc,
@@ -54,3 +64,6 @@ from ._lm_co import (
 from ._meta import get_version as _get_version
 
 __version__: _Final[str] = _get_version()
+
+if not _TYPE_CHECKING:
+    _patch_rv()

--- a/lmo/_distns.py
+++ b/lmo/_distns.py
@@ -185,7 +185,7 @@ class l_sample_rv(rv_continuous):  # noqa: N801
         # empirical support
         self._a0, self._b0 = (q0, q1) = ppf(np.array([0, 1]))
         if q0 >= q1:
-            msg = 'invalid l_rv: ppf(0) >= ppf(1)'
+            msg = 'invalid l_sample_rv: ppf(0) >= ppf(1)'
             raise ArithmeticError(msg)
 
         kwargs.setdefault('momtype', 1)
@@ -342,7 +342,8 @@ class l_sample_rv(rv_continuous):  # noqa: N801
         trim: AnyTrim = (0, 0),
     ) -> 'l_sample_rv':
         r"""
-        Estimate L-moment from the samples, and return a new `l_rv` instance.
+        Estimate L-moment from the samples, and return a new `l_sample_rv`
+        instance.
 
         Args:
             data:
@@ -356,7 +357,7 @@ class l_sample_rv(rv_continuous):  # noqa: N801
                 to the provided `l_moments`.
 
         Returns:
-            A fitted [`l_rv`][lmo.l_rv] instance.
+            A fitted [`l_sample_rv`][lmo.l_sample_rv] instance.
 
         Todo:
             - Optimal `rmax` selection (the error appears to be periodic..?)

--- a/lmo/_distns.py
+++ b/lmo/_distns.py
@@ -794,7 +794,6 @@ class l_rv_generic(PatchClass):  # noqa: N801
         return float(self.l_ratio(4, 2, *args, trim=trim, **kwds))
 
 
-
 class l_rv_frozen(PatchClass):  # noqa: N801
     dist: l_rv_generic
     args: tuple[Any, ...]
@@ -825,21 +824,6 @@ class l_rv_frozen(PatchClass):  # noqa: N801
         trim: AnyTrim = (0, 0),
         quad_opts: QuadOptions | None = None,
     ) -> np.float_ | npt.NDArray[np.float_]:
-        """L-moment(s) of distribution of specified order(s).
-
-        Parameters
-        ----------
-        order : array_like
-            Order(s) of L-moment(s).
-        trim : float or tuple, optional
-            left- and right- trim (default=(0, 0))
-
-        Returns
-        -------
-        lm : ndarray or scalar
-            The calculated L-moment(s).
-
-        """  # noqa: D416
         return self.dist.l_moment(
             order,
             *self.args,
@@ -876,23 +860,6 @@ class l_rv_frozen(PatchClass):  # noqa: N801
         trim: AnyTrim = (0, 0),
         quad_opts: QuadOptions | None = None,
     ) -> np.float_ | npt.NDArray[np.float_]:
-        """L-moment ratio('s) of distribution of specified order(s).
-
-        Parameters
-        ----------
-        order : array_like
-            Order(s) of L-moment(s).
-        order_denom : array_like
-            Order(s) of L-moment denominator(s).
-        trim : float or tuple, optional
-            left- and right- trim (default=(0, 0))
-
-        Returns
-        -------
-        tm : ndarray or scalar
-            The calculated L-moment ratio('s).
-
-        """  # noqa: D416
         return self.dist.l_ratio(
             order,
             order_denom,
@@ -908,25 +875,6 @@ class l_rv_frozen(PatchClass):  # noqa: N801
         moments: int = 4,
         quad_opts: QuadOptions | None = None,
     ) -> np.float_ | npt.NDArray[np.float_]:
-        """L-moments (order <= 2) and L-moment ratio's (order > 2).
-
-        By default, the first `num = 4` L-stats are calculated. This is
-        equivalent to `l_ratio([1, 2, 3, 4], [0, 0, 2, 2], *, **)`, i.e. the
-        L-location, L-scale, L-skew, and L-kurtosis.
-
-        Parameters
-        ----------
-        trim : float or tuple, optional
-            left- and right- trim (default=(0, 0))
-        moments : int, optional
-            the amount of L-moment stats to compute (default=4)
-
-        Returns
-        -------
-        tm : ndarray or scalar
-            The calculated L-moment ratio('s).
-
-        """  # noqa: D416
         return self.dist.l_stats(
             *self.args,
             trim=trim,
@@ -936,78 +884,18 @@ class l_rv_frozen(PatchClass):  # noqa: N801
         )
 
     def l_loc(self, trim: AnyTrim = (0, 0)) -> float:
-        """L-location of the distribution, i.e. the 1st L-moment.
-
-        Without trim (default), the L-location is equivalent to the mean.
-
-        Parameters
-        ----------
-        trim : float or tuple, optional
-            left- and right- trim (default=(0, 0))
-
-        Returns
-        -------
-        l_loc : float
-            The L-location of the distribution.
-
-        """  # noqa: D416
         return self.dist.l_loc(*self.args, trim=trim, **self.kwds)
 
 
     def l_scale(self, trim: AnyTrim = (0, 0)) -> float:
-        """L-scale of the distribution, i.e. the 2nd L-moment.
-
-        Without trim (default), the L-location is equivalent to half the Gini
-        mean (absolute) difference (GMD).
-
-        Just like the standard deviation, the L-scale is location-invariant,
-        and varies proportionally to positive scaling.
-
-        Parameters
-        ----------
-        trim : float or tuple, optional
-            left- and right- trim (default=(0, 0))
-
-        Returns
-        -------
-        l_scale : float
-            The L-scale of the distribution.
-
-        """  # noqa: D416
         return self.dist.l_scale(*self.args, trim=trim, **self.kwds)
 
 
     def l_skew(self, trim: AnyTrim = (0, 0)) -> float:
-        """L-skewness coefficient of the distribution; the 3rd L-moment ratio.
-
-        Parameters
-        ----------
-        trim : float or tuple, optional
-            left- and right- trim (default=(0, 0))
-
-        Returns
-        -------
-        l_skew : float
-            The L-skewness coefficient of the distribution.
-
-        """  # noqa: D416
         return self.dist.l_skew(*self.args, trim=trim, **self.kwds)
 
 
     def l_kurtosis(self, trim: AnyTrim = (0, 0)) -> float:
-        """L-kurtosis coefficient of the distribution; the 4th L-moment ratio.
-
-        Parameters
-        ----------
-        trim : float or tuple, optional
-            left- and right- trim (default=(0, 0))
-
-        Returns
-        -------
-        l_kurtosis : float
-            The L-kurtosis coefficient of the distribution.
-
-        """  # noqa: D416
         return self.dist.l_kurtosis(*self.args, trim=trim, **self.kwds)
 
 

--- a/lmo/_distns.py
+++ b/lmo/_distns.py
@@ -1,6 +1,6 @@
 # pyright: reportIncompatibleMethodOverride=false
 
-__all__ = ('l_rv', 'rv_method')
+__all__ = ('l_sample_rv', 'rv_method')
 
 import functools
 import math
@@ -36,7 +36,7 @@ from .typing import (
     QuadOptions,
 )
 
-X = TypeVar('X', bound='l_rv')
+X = TypeVar('X', bound='l_sample_rv')
 F = TypeVar('F', bound=np.floating[Any])
 M = TypeVar('M', bound=Callable[..., Any])
 
@@ -85,7 +85,7 @@ def _ppf_poly_series(
     )
 
 
-class l_rv(rv_continuous):  # noqa: N801
+class l_sample_rv(rv_continuous):  # noqa: N801
     r"""
     Estimate a distribution using the given L-moments.
     See [`scipy.stats.rv_continuous`][scipy.stats.rv_continuous] for the
@@ -340,7 +340,7 @@ class l_rv(rv_continuous):  # noqa: N801
         /,
         rmax: SupportsIndex | None = None,
         trim: AnyTrim = (0, 0),
-    ) -> 'l_rv':
+    ) -> 'l_sample_rv':
         r"""
         Estimate L-moment from the samples, and return a new `l_rv` instance.
 

--- a/lmo/_distns.py
+++ b/lmo/_distns.py
@@ -430,7 +430,7 @@ def _patch_rv_frozen() -> bool:
             return getattr(self.dist, name)(  # type: ignore
                 *args,
                 *self.args,
-                *kwds,
+                **kwds,
                 **self.kwds,
             )
 

--- a/lmo/_utils.py
+++ b/lmo/_utils.py
@@ -15,8 +15,6 @@ from typing import Any, SupportsIndex, TypeVar
 import numpy as np
 import numpy.typing as npt
 
-from .typing import AnyInt, IntVector
-
 from .typing import AnyInt, AnyTrim, IndexOrder, IntVector, SortKind
 
 T = TypeVar('T', bound=np.generic)

--- a/lmo/_utils.py
+++ b/lmo/_utils.py
@@ -15,6 +15,8 @@ from typing import Any, SupportsIndex, TypeVar
 import numpy as np
 import numpy.typing as npt
 
+from .typing import AnyInt, IntVector
+
 from .typing import AnyInt, AnyTrim, IndexOrder, IntVector, SortKind
 
 T = TypeVar('T', bound=np.generic)
@@ -253,3 +255,10 @@ def l_stats_orders(
         np.arange(1, num + 1),
         np.array([0] * min(2, num) + [2] * (num - 2)),
     )
+
+
+def broadstack(
+    r: AnyInt | IntVector,
+    s: AnyInt | IntVector,
+) -> npt.NDArray[np.int_]:
+    return np.stack(np.broadcast_arrays(np.asarray(r), np.asarray(s)))

--- a/lmo/diagnostic.py
+++ b/lmo/diagnostic.py
@@ -580,7 +580,7 @@ def rejection_point(
     $$
 
     with a $\epsilon$ a small positive number, corresponding to the `tol` param
-    of e.g. `lmo.theoretical.l_moment_influence`, which defaults to `1e-8`.
+    of e.g. `lmo.l_rv_generic.l_moment_influence`, which defaults to `1e-8`.
 
     Examples:
         The untrimmed L-location isn't robust, e.g. with the standard normal
@@ -589,8 +589,7 @@ def rejection_point(
         >>> import numpy as np
         >>> from scipy.stats import distributions as dists
         >>> from lmo.diagnostic import rejection_point
-        >>> from lmo.theoretical import l_moment_influence
-        >>> if_l_loc_norm = l_moment_influence(dists.norm, 1, trim=0)
+        >>> if_l_loc_norm = dists.norm.l_moment_influence(1, trim=0)
         >>> if_l_loc_norm(np.inf)
         inf
         >>> rejection_point(if_l_loc_norm)
@@ -600,8 +599,8 @@ def rejection_point(
         Student's t distribution with 4 degrees of freedom (3 also works, but
         is very slow), they exist.
 
-        >>> if_tl_loc_norm = l_moment_influence(dists.norm, 1, trim=1)
-        >>> if_tl_loc_t4 = l_moment_influence(dists.t(4), 1, trim=1)
+        >>> if_tl_loc_norm = dists.norm.l_moment_influence(1, trim=1)
+        >>> if_tl_loc_t4 = dists.t(4).l_moment_influence(1, trim=1)
         >>> if_tl_loc_norm(np.inf), if_tl_loc_t4(np.inf)
         (0.0, 0.0)
         >>> rejection_point(if_tl_loc_norm), rejection_point(if_tl_loc_t4)
@@ -629,8 +628,7 @@ def rejection_point(
         A finite or infinite scalar.
 
     See Also:
-        - [`l_moment_influence`][lmo.theoretical.l_moment_influence]
-        - [`l_ratio_influence`][lmo.theoretical.l_ratio_influence]
+        - [`l_moment_influence`][lmo.l_rv_generic.l_moment_influence]
         - [`error_sensitivity`][lmo.diagnostic.error_sensitivity]
 
     """
@@ -684,10 +682,9 @@ def error_sensitivity(
         ($\tau^{(0, 1)}_4$) coefficients:
 
         >>> from lmo.diagnostic import error_sensitivity
-        >>> from lmo.theoretical import l_ratio_influence
         >>> from scipy.stats import expon
-        >>> ll_skew_if = l_ratio_influence(expon, 3, trim=(0, 1))
-        >>> ll_kurt_if = l_ratio_influence(expon, 4, trim=(0, 1))
+        >>> ll_skew_if = expon.l_ratio_influence(3, 2, trim=(0, 1))
+        >>> ll_kurt_if = expon.l_ratio_influence(4, 2, trim=(0, 1))
         >>> error_sensitivity(ll_skew_if, domain=(0, float('inf')))
         1.814657...
         >>> error_sensitivity(ll_kurt_if, domain=(0, float('inf')))
@@ -701,8 +698,7 @@ def error_sensitivity(
         Gross-error sensitivity $\gamma^*_{T|F}$ .
 
     See Also:
-        - [`l_moment_influence`][lmo.theoretical.l_moment_influence]
-        - [`l_ratio_influence`][lmo.theoretical.l_ratio_influence]
+        - [`l_moment_influence`][lmo.l_rv_generic.l_moment_influence]
         - [`rejection_point`][lmo.diagnostic.rejection_point]
 
     """
@@ -760,10 +756,9 @@ def shift_sensitivity(
         ($\tau^{(0, 1)}_4$) coefficients:
 
         >>> from lmo.diagnostic import shift_sensitivity
-        >>> from lmo.theoretical import l_ratio_influence
         >>> from scipy.stats import expon
-        >>> ll_skew_if = l_ratio_influence(expon, 3, trim=(0, 1))
-        >>> ll_kurt_if = l_ratio_influence(expon, 4, trim=(0, 1))
+        >>> ll_skew_if = expon.l_ratio_influence(3, 2, trim=(0, 1))
+        >>> ll_kurt_if = expon.l_ratio_influence(4, 2, trim=(0, 1))
         >>> domain = 0, float('inf')
         >>> shift_sensitivity(ll_skew_if, domain)
         0.837735...
@@ -772,9 +767,9 @@ def shift_sensitivity(
 
         Let's compare these with the untrimmed ones:
 
-        >>> shift_sensitivity(l_ratio_influence(expon, 3), domain)
+        >>> shift_sensitivity(expon.l_ratio_influence(3, 2), domain)
         1.920317...
-        >>> shift_sensitivity(l_ratio_influence(expon, 4), domain)
+        >>> shift_sensitivity(expon.l_ratio_influence(4, 2), domain)
         1.047565...
 
     Args:
@@ -785,8 +780,7 @@ def shift_sensitivity(
         Local-shift sensitivity $\lambda^*_{T|F}$ .
 
     See Also:
-        - [`l_moment_influence`][lmo.theoretical.l_moment_influence]
-        - [`l_ratio_influence`][lmo.theoretical.l_ratio_influence]
+        - [`l_moment_influence`][lmo.l_rv_generic.l_moment_influence]
         - [`error_sensitivity`][lmo.diagnostic.error_sensitivity]
 
     References:

--- a/lmo/theoretical.py
+++ b/lmo/theoretical.py
@@ -1881,6 +1881,7 @@ Methods to be added to `scipy.stats.rv_generic` and `scipy.stats.rv_frozen`.
 def _rv_l_moment(  # type: ignore
     self: rv_continuous | rv_discrete,
     order: AnyInt | IntVector,
+    /,
     *args: float,
     trim: AnyTrim = (0, 0),
     **kwds: float,
@@ -1938,6 +1939,7 @@ def _rv_l_ratio(  # type: ignore
     self: rv_continuous | rv_discrete,
     order: AnyInt | IntVector,
     order_denom: AnyInt | IntVector,
+    /,
     *args: float,
     trim: AnyTrim = (0, 0),
     **kwds: float,
@@ -1972,3 +1974,44 @@ def _rv_l_ratio(  # type: ignore
         self.l_moment(rs, *args, trim=trim, **kwds),  # type: ignore
     )
     return moments_to_ratio(rs, lms)
+
+
+@rv_method('l_stats')
+def _rv_l_stats(  # type: ignore
+    self: rv_continuous | rv_discrete,
+    *args: float,
+    trim: AnyTrim = (0, 0),
+    moments: int = 4,
+    **kwds: float,
+) -> np.float_ | npt.NDArray[np.float_]:
+    """L-moments (order <= 2) and L-moment ratio's (order > 2).
+
+    By default, the first `num = 4` L-stats are calculated. This is
+    equivalent to `l_ratio([1, 2, 3, 4], [0, 0, 2, 2], *, **)`, i.e. the
+    L-location, L-scale, L-skew, and L-kurtosis.
+
+    Parameters
+    ----------
+    arg1, arg2, arg3,... : float
+        The shape parameter(s) for the distribution (see docstring of the
+        instance object for more information)
+    loc : float, optional
+        location parameter (default=0)
+    scale : float, optional
+        scale parameter (default=1)
+    trim : float or tuple, optional
+        left- and right- trim (default=(0, 0))
+    moments : int, optional
+        the amount of L-moment stats to compute (default=4)
+
+    Returns
+    -------
+    tm : ndarray or scalar
+        The calculated L-moment ratio('s).
+
+    """  # noqa: D416
+    r, s = l_stats_orders(moments)
+    return cast(
+        npt.NDArray[np.float_],
+        self.l_ratio(r, s, *args, trim=trim, **kwds),  # type: ignore
+    )

--- a/lmo/theoretical.py
+++ b/lmo/theoretical.py
@@ -2041,3 +2041,146 @@ def _rv_l_stats(  # type: ignore
             **kwds,
         ),
     )
+
+
+@rv_method('l_loc')
+def _rv_l_loc(  # type: ignore
+    self: rv_continuous | rv_discrete,
+    *args: float,
+    trim: AnyTrim = (0, 0),
+    **kwds: float,
+) -> float:
+    """L-location of the distribution, i.e. the 1st L-moment.
+
+    Without trim (default), the L-location is equivalent to the mean.
+
+    Parameters
+    ----------
+    arg1, arg2, arg3,... : float
+        The shape parameter(s) for the distribution (see docstring of the
+        instance object for more information)
+    loc : float, optional
+        location parameter (default=0)
+    scale : float, optional
+        scale parameter (default=1)
+    trim : float or tuple, optional
+        left- and right- trim (default=(0, 0))
+
+    Returns
+    -------
+    l_loc : float
+        The L-location of the distribution.
+
+    """  # noqa: D416
+    if not any(clean_trim(trim)):
+        return cast(float, self.mean(*args, **kwds))
+
+    return cast(
+        float,
+        self.l_moment(1, *args, trim=trim, **kwds),  # type: ignore
+    )
+
+
+@rv_method('l_scale')
+def _rv_l_scale(  # type: ignore
+    self: rv_continuous | rv_discrete,
+    *args: float,
+    trim: AnyTrim = (0, 0),
+    **kwds: float,
+) -> float:
+    """L-scale of the distribution, i.e. the 2nd L-moment.
+
+    Without trim (default), the L-location is equivalent to half the Gini
+    mean (absolute) difference (GMD).
+
+    Just like the standard deviation, the L-scale is location-invariant, and
+    varies proportionally to positive scaling.
+
+    Parameters
+    ----------
+    arg1, arg2, arg3,... : float
+        The shape parameter(s) for the distribution (see docstring of the
+        instance object for more information)
+    loc : float, optional
+        location parameter (default=0)
+    scale : float, optional
+        scale parameter (default=1)
+    trim : float or tuple, optional
+        left- and right- trim (default=(0, 0))
+
+    Returns
+    -------
+    l_scale : float
+            The L-scale of the distribution.
+
+    """  # noqa: D416
+    return cast(
+        float,
+        self.l_moment(2, *args, trim=trim, **kwds),  # type: ignore
+    )
+
+
+@rv_method('l_skew')
+def _rv_l_skew(  # type: ignore
+    self: rv_continuous | rv_discrete,
+    *args: float,
+    trim: AnyTrim = (0, 0),
+    **kwds: float,
+) -> float:
+    """L-skewness coefficient of the distribution; the 3rd L-moment ratio.
+
+    Parameters
+    ----------
+    arg1, arg2, arg3,... : float
+        The shape parameter(s) for the distribution (see docstring of the
+        instance object for more information)
+    loc : float, optional
+        location parameter (default=0)
+    scale : float, optional
+        scale parameter (default=1)
+    trim : float or tuple, optional
+        left- and right- trim (default=(0, 0))
+
+    Returns
+    -------
+    l_skew : float
+        The L-skewness coefficient of the distribution.
+
+    """  # noqa: D416
+    return cast(
+        float,
+        self.l_ratio(3, 2, *args, trim=trim, **kwds),  # type: ignore
+    )
+
+
+@rv_method('l_kurtosis')
+def _rv_l_kurtosis(  # type: ignore
+    self: rv_continuous | rv_discrete,
+    *args: float,
+    trim: AnyTrim = (0, 0),
+    **kwds: float,
+) -> float:
+    """L-kurtosis coefficient of the distribution; the 4th L-moment ratio.
+
+    Parameters
+    ----------
+    arg1, arg2, arg3,... : float
+        The shape parameter(s) for the distribution (see docstring of the
+        instance object for more information)
+    loc : float, optional
+        location parameter (default=0)
+    scale : float, optional
+        scale parameter (default=1)
+    trim : float or tuple, optional
+        left- and right- trim (default=(0, 0))
+
+    Returns
+    -------
+    l_kurtosis : float
+        The L-kurtosis coefficient of the distribution.
+
+    """  # noqa: D416
+    return cast(
+        float,
+        self.l_ratio(4, 2, *args, trim=trim, **kwds),  # type: ignore
+    )

--- a/lmo/theoretical.py
+++ b/lmo/theoretical.py
@@ -774,6 +774,8 @@ def l_moment_from_rv(
             L-moments](https://doi.org/10.1016/j.jspi.2006.12.002)
 
     See Also:
+        - [`rv.generic.l_moment`][lmo.l_rv_generic.l_moment]:
+          method of `scipy.stats` distributions.
         - [`l_moment_from_cdf`][lmo.theoretical.l_moment_from_cdf]:
           population L-moment, using the cumulative distribution function.
         - [`l_moment_from_ppf`][lmo.theoretical.l_moment_from_ppf]:

--- a/lmo/theoretical.py
+++ b/lmo/theoretical.py
@@ -1884,7 +1884,7 @@ def _rv_l_moment(  # type: ignore
     *args: float,
     trim: AnyTrim = (0, 0),
     **kwds: float,
-) -> float | npt.NDArray[np.float_]:
+) -> np.float_ | npt.NDArray[np.float_]:
     """L-moment(s) of distribution of specified order(s).
 
     Parameters
@@ -1927,7 +1927,48 @@ def _rv_l_moment(  # type: ignore
     else:
         cdf, ppf = _cdf, _ppf
 
-    lm = l_moment_from_cdf(cdf, rs, trim, support=support, ppf=ppf)
+    lm = np.asarray(l_moment_from_cdf(cdf, rs, trim, support=support, ppf=ppf))
     lm[rs == 1] += loc
     lm[rs > 1] *= scale
     return lm[()]  # convert back to scalar if needed
+
+
+@rv_method('l_ratio')
+def _rv_l_ratio(  # type: ignore
+    self: rv_continuous | rv_discrete,
+    order: AnyInt | IntVector,
+    order_denom: AnyInt | IntVector,
+    *args: float,
+    trim: AnyTrim = (0, 0),
+    **kwds: float,
+) -> np.float_ | npt.NDArray[np.float_]:
+    """L-moment ratio('s) of distribution of specified order(s).
+
+    Parameters
+    ----------
+    order : array_like
+        Order(s) of L-moment(s).
+    order_denom : array_like
+        Order(s) of L-moment denominator(s).
+    arg1, arg2, arg3,... : float
+        The shape parameter(s) for the distribution (see docstring of the
+        instance object for more information)
+    loc : float, optional
+        location parameter (default=0)
+    scale : float, optional
+        scale parameter (default=1)
+    trim : float or tuple, optional
+        left- and right- trim (default=(0, 0))
+
+    Returns
+    -------
+    tm : ndarray or scalar
+        The calculated L-moment ratio('s).
+
+    """  # noqa: D416
+    rs = _stack_orders(order, order_denom)
+    lms = cast(
+        npt.NDArray[np.float_],
+        self.l_moment(rs, *args, trim=trim, **kwds),  # type: ignore
+    )
+    return moments_to_ratio(rs, lms)


### PR DESCRIPTION
towards #10 

Added the following methods to all subtypes of`rv_generic` and `rv_frozen`:

- `l_loc`
- `l_scale`
- `l_skew`
- `l_kurtosis`
- `l_moment`
- `l_ratio`
- `l_stats`
- `l_moments_cov`
- `l_stats_cov`
- `l_moment_influence`
- `l_ratio_influence`
