### PR TITLE
Optional Pandas integration

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,8 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12']
-        pandas: [false, true]
+        python-version: ['3.10', '3.12']
+        pandas: ['without', 'with']
 
     runs-on: ${{ matrix.os }}
 
@@ -41,12 +41,12 @@ jobs:
         run: poetry check
 
       - name: install
-        run: poetry install --sync --without docs --without debug --without pandas
-        if: ${{ ! matrix.pandas }}
-
-      - name: install (with pandas)
-        run: poetry install --sync --without docs --without debug
-        if: ${{ matrix.pandas }}
+        run: >
+          poetry install
+          --sync
+          --without docs
+          --without debug
+          --${{ matrix.pandas }} pandas
 
       - name: codespell
         run: poetry run codespell .

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        # os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         python-version: ['3.10', '3.12']
         pandas: ['without', 'with']
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,13 +13,16 @@ concurrency:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: ['3.10', '3.11', '3.12']
+        pandas: [false, true]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: checkout
@@ -38,7 +41,12 @@ jobs:
         run: poetry check
 
       - name: install
+        run: poetry install --sync --without docs --without debug --without pandas
+        if: ${{ ! matrix.pandas }}
+
+      - name: install (with pandas)
         run: poetry install --sync --without docs --without debug
+        if: ${{ matrix.pandas }}
 
       - name: codespell
         run: poetry run codespell .

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Uniform or multi-dimensional, Lmo can summarize it all with one quick glance!
 ~~~
 
 Unlike the legacy [moments](https://wikipedia.org/wiki/Moment_(mathematics)),
-[L-moments](https://wikipedia.org/wiki/L-moment) **uniquely describe** a 
+[L-moments](https://wikipedia.org/wiki/L-moment) **uniquely describe** a
 probability distribution, and are more robust and efficient.
 The "L" stands for Linear; it is a linear combination of order statistics.
 So Lmo is as fast as sorting your samples (in terms of time-complexity).
@@ -38,20 +38,21 @@ So Lmo is as fast as sorting your samples (in terms of time-complexity).
 - Fast estimation of L-*co*moment matrices from your multidimensional data
   or multivariate distribution.
 - Goodness-of-fit test, using L-moment or L-moment ratio's.
-- Non-parametric estimation of continuous distributions 
+- Non-parametric estimation of continuous distributions
   with `lmo.l_rv_nonparametric`
 - Exact (co)variance structure of the sample- and population L-moments.
 - Theoretical & empirical influence functions of L-moments & L-ratio's.
-- Complete [docs](https://jorenham.github.io/lmo/), including detailed API 
+- Complete [docs](https://jorenham.github.io/lmo/), including detailed API
 reference with usage examples and with mathematical $\TeX$ definitions.
 - Clean Pythonic syntax for ease of use.
 - Vectorized functions for very fast fitting.
 - Fully typed, tested, and tickled.
+- Optional Pandas integration.
 
 ## Quick example
 
-Even if your data is pathological like 
-[Cauchy](https://wikipedia.org/wiki/Cauchy_distribution), and the L-moments 
+Even if your data is pathological like
+[Cauchy](https://wikipedia.org/wiki/Cauchy_distribution), and the L-moments
 are not defined, the trimmed L-moments (TL-moments) can be used instead.
 Let's calculate the TL-location and TL-scale of a small amount of samples:
 
@@ -77,12 +78,10 @@ array([0.        , 0.69782723])
 See the [documentation](https://jorenham.github.io/lmo/) for more examples and
 the API reference.
 
-
 ## Roadmap
 
 - Automatic trim-length selection.
 - Plotting utilities (deps optional), e.g. for L-moment ratio diagrams.
-
 
 ## Installation
 
@@ -92,28 +91,36 @@ Lmo is on [PyPI](https://pypi.org/project/lmo/), so you can do something like:
 pip install lmo
 ```
 
-## Dependencies
+### Required dependencies
 
-- `python >= 3.10`
-- `numpy >= 1.22`
-- `scipy >= 1.9`
+These are automatically installed by your package manager, alongside `lmo`.
 
+| Package | Minimum version |
+| --- | --- |
+| [Python](https://github.com/python/cpython) | `3.10` |
+| [NumPy](https://github.com/numpy/numpy) | `1.22` |
+| [SciPy](https://github.com/scipy/scipy) | `1.9` |
+
+### Optional dependencies
+
+| Package | Minimum version | Notes
+| --- | --- | --- |
+| [Pandas](https://github.com/pandas-dev/pandas) | `1.4` | Lmo extends `pd.Series` and `pd.DataFrame` with convenient methods, e.g. `df.l_scale(trim=1)`. Install as `pip install lmo[pandas]` to ensure compatibility. |
 
 ## Foundational Literature
 
-- [*J.R.M. Hosking* (1990) &ndash; L-moments: Analysis and Estimation of 
+- [*J.R.M. Hosking* (1990) &ndash; L-moments: Analysis and Estimation of
   Distributions using Linear Combinations of Order Statistics
   ](https://doi.org/10.1111/j.2517-6161.1990.tb01775.x)
 - [*E.A.H. Elamir & A.H. Seheult* (2003) &ndash; Trimmed L-moments
   ](https://doi.org/10.1016/S0167-9473(02)00250-5)
-- [*E.A.H. Elamir & A.H. Seheult* (2004) &ndash; Exact variance structure of 
+- [*E.A.H. Elamir & A.H. Seheult* (2004) &ndash; Exact variance structure of
   sample L-moments](https://doi.org/10.1016/S0378-3758(03)00213-1)
-- [*J.R.M. Hosking* (2007) &ndash; Some theory and practical uses of trimmed 
+- [*J.R.M. Hosking* (2007) &ndash; Some theory and practical uses of trimmed
   L-moments](https://doi.org/10.1016/j.jspi.2006.12.002)
-- [*R. Serﬂing & P. Xiao* (2007) &ndash; A contribution to multivariate 
+- [*R. Serﬂing & P. Xiao* (2007) &ndash; A contribution to multivariate
   L-moments: L-comoment matrices](https://doi.org/10.1016/j.jmva.2007.01.008)
-- [*W.H. Asquith* (2011) &ndash; Univariate Distributional Analysis with 
+- [*W.H. Asquith* (2011) &ndash; Univariate Distributional Analysis with
   L-moment Statistics](https://hdl.handle.net/2346/ETD-TTU-2011-05-1319)
-
 
 <!--overview-end-->

--- a/docs/api.md
+++ b/docs/api.md
@@ -35,6 +35,7 @@
       show_bases: false
       members:
       - Series
+      - DataFrame
       heading_level: 4
 
 ### Distributions

--- a/docs/api.md
+++ b/docs/api.md
@@ -19,13 +19,22 @@
       filters: ["^l_co"]
       heading_level: 4
 
-### Integration with `scipy.stats` distributions
+### `scipy.stats` extensions
 
 ::: lmo.contrib.scipy_stats
     options:
       show_bases: false
       members:
       - l_rv_generic
+      heading_level: 4
+
+### `pandas` extensions (optional)
+
+::: lmo.contrib.pandas
+    options:
+      show_bases: false
+      members:
+      - Series
       heading_level: 4
 
 ### Distributions

--- a/lmo/__init__.py
+++ b/lmo/__init__.py
@@ -34,7 +34,7 @@ __all__ = (
     'l_rv_nonparametric',
 )
 
-from typing import Final as _Final
+from typing import TYPE_CHECKING, Final
 
 from ._distns import (
     l_rv_nonparametric,
@@ -67,9 +67,10 @@ from ._lm_co import (
 )
 from ._meta import get_version as _get_version
 
+if not TYPE_CHECKING:
 # install contrib module extensions
-from .contrib import install as _install
+    from .contrib import install as _install
 
-_install()
+    _install()
 
-__version__: _Final[str] = _get_version()
+__version__: Final[str] = _get_version()

--- a/lmo/contrib/__init__.py
+++ b/lmo/contrib/__init__.py
@@ -1,8 +1,7 @@
 """Integrations and extensions for 3rd party packages."""
+import contextlib
 
 __all__ = ('install',)
-
-from . import scipy_stats
 
 
 def install():
@@ -12,4 +11,9 @@ def install():
     There should be no need to call this manually: this is done automatically
     when `lmo` is imported.
     """
+    from . import scipy_stats
     scipy_stats.install()
+
+    with contextlib.suppress(ImportError):
+        from . import pandas
+        pandas.install()

--- a/lmo/contrib/__init__.py
+++ b/lmo/contrib/__init__.py
@@ -1,7 +1,11 @@
 """Integrations and extensions for 3rd party packages."""
-import contextlib
 
 __all__ = ('install',)
+
+try:
+    import pandas as pd  # type: ignore
+except ImportError:
+    pd = None
 
 
 def install():
@@ -11,9 +15,9 @@ def install():
     There should be no need to call this manually: this is done automatically
     when `lmo` is imported.
     """
-    from . import scipy_stats
-    scipy_stats.install()
+    from .scipy_stats import install as install_scipy_stats
+    install_scipy_stats()
 
-    with contextlib.suppress(ImportError):
-        from . import pandas
-        pandas.install()
+    if pd is not None:
+        from .pandas import install as install_pandas
+        install_pandas()

--- a/lmo/contrib/pandas.py
+++ b/lmo/contrib/pandas.py
@@ -3,6 +3,40 @@ Extension methods for `pandas.Series` and `pandas.DataFrame`.
 
 Pandas is an optional dependency, and can be installed using
 `pip install lmo[pandas]`.
+
+Examples:
+    Univariate summary statistics:
+
+    ```pycon
+    >>> df = pd.DataFrame({'a': [1, 2, 2, 3, 4], 'b': [3, 4, 4, 4, 4]})
+    >>> df.l_stats()
+            a    b
+    r
+    1  2.400000  3.8
+    2  0.700000  0.2
+    3  0.142857 -1.0
+    4  0.285714  1.0
+    >>> df.aggregate(['mean', 'std', 'skew', 'kurt'])
+                a         b
+    mean  2.400000  3.800000
+    std   1.140175  0.447214
+    skew  0.404796 -2.236068
+    kurt -0.177515  5.000000
+    ```
+
+    Comparison of L-correlation, and Pearson correlation matrices:
+
+    ```pycon
+    >>> df = pd.DataFrame({'dogs': [.2, .0, .5, .4], 'cats': [.3, .2, .0, .1]})
+    >>> df.l_corr()
+        dogs      cats
+    dogs   1.0 -0.764706
+    cats  -0.8  1.000000
+    >>> df.corr()
+            dogs      cats
+    dogs  1.000000 -0.756889
+    cats -0.756889  1.000000
+    ```
 """
 __all__ = (
     'Series',

--- a/lmo/contrib/pandas.py
+++ b/lmo/contrib/pandas.py
@@ -1,0 +1,87 @@
+"""Extension methods for `pandas.Series` and `pandas.DataFrame`."""
+from __future__ import annotations
+
+__all__ = (
+    'l_moment',
+    'install',
+)
+
+import sys
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
+
+import numpy as np
+import pandas as pd
+
+from lmo import l_moment as _l_moment
+
+if TYPE_CHECKING:
+    from lmo.typing import AnyInt, AnyTrim, IntVector, LMomentOptions
+
+if sys.version_info < (3, 11):
+    from typing_extensions import Unpack
+else:
+    from typing import Unpack
+
+T = TypeVar(
+    'T',
+    bound=(
+        bool
+        | int
+        | float
+        | np.dtype[np.bool_]
+        | np.dtype[np.integer[Any]]
+        | np.dtype[np.floating[Any]]
+    ),
+)
+
+class l_moment(Generic[T]):  # noqa: N801
+    """Extension method for `pandas.Series`."""
+    __slots__ = ('_obj',)
+
+    _obj: pd.Series[T]
+
+    def __init__(self, obj: pd.Series[T]) -> None:  # noqa: D107
+        self._validate(obj)
+        self._obj = obj
+
+    @classmethod
+    def _validate(cls, obj: pd.Series[T]) -> None:
+        if not pd.api.types.is_any_real_numeric_dtype(obj):  # type: ignore
+            msg = f'Can only use .{cls.__name__} accessor with numeric values'
+            raise AttributeError(msg)
+
+    def __call__(  # noqa: D102
+        self,
+        r: IntVector | AnyInt,
+        /,
+        trim: AnyTrim = (0, 0),
+        **kwargs: Unpack[LMomentOptions],
+    ) -> pd.Series[float] | float:
+        _r = np.asarray(r).ravel()
+
+        res = _l_moment(
+            np.asarray(self._obj, float),
+            _r,
+            trim=trim,
+            **kwargs,
+        )
+
+        if len(res) == 1:
+            return res[0]
+
+        return pd.Series(
+            res,
+            index=_r,
+            name='l_moment',
+            dtype=float,
+        )
+
+
+def install():
+    """Register the accessor methods."""
+    for method in [  # type: ignore
+        l_moment,
+    ]:
+        pd.api.extensions.register_series_accessor(  # type: ignore
+            method.__name__,
+        )(method)

--- a/lmo/contrib/pandas.py
+++ b/lmo/contrib/pandas.py
@@ -62,12 +62,14 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 
-from lmo import (
-    l_comoment as _l_comoment,
-    l_coratio as _l_coratio,
+from lmo._lm import (
     l_moment as _l_moment,
     l_ratio as _l_ratio,
     l_stats as _l_stats,
+)
+from lmo._lm_co import (
+    l_comoment as _l_comoment,
+    l_coratio as _l_coratio,
 )
 from lmo._utils import broadstack, clean_trim, moments_to_ratio
 from lmo.typing import (

--- a/lmo/contrib/pandas.py
+++ b/lmo/contrib/pandas.py
@@ -361,10 +361,9 @@ class DataFrame(pd.DataFrame):
         **kwargs: Unpack[LMomentOptions],
     ) -> 'pd.Series[float]':
         """
-        See [`lmo.l_loc`][lmo.l_loc].
-
-        Returns:
-            out: A [`Series[float]`][pandas.Series].
+        Alias for
+        [`l_moment(1, ...)`][lmo.contrib.pandas.DataFrame.l_moment].
+        See [`lmo.l_loc`][lmo.l_loc] for details.
         """
         return self.apply(  # type: ignore
             _l_moment,
@@ -380,10 +379,9 @@ class DataFrame(pd.DataFrame):
         **kwargs: Unpack[LMomentOptions],
     ) -> 'pd.Series[float]':
         """
-        See [`lmo.l_scale`][lmo.l_scale].
-
-        Returns:
-            out: A [`Series[float]`][pandas.Series].
+        Alias for
+        [`l_moment(2, ...)`][lmo.contrib.pandas.DataFrame.l_moment].
+        See [`lmo.l_scale`][lmo.l_scale] for details.
         """
         return self.apply(  # type: ignore
             _l_moment,
@@ -399,10 +397,9 @@ class DataFrame(pd.DataFrame):
         **kwargs: Unpack[LMomentOptions],
     ) -> 'pd.Series[float]':
         """
-        See [`lmo.l_variation`][lmo.l_variation].
-
-        Returns:
-            out: A [`Series[float]`][pandas.Series].
+        Alias for
+        [`l_ratio(2, 1, ...)`][lmo.contrib.pandas.DataFrame.l_ratio].
+        See [`lmo.l_variation`][lmo.l_variation] for details.
         """
         return self.apply(  # type: ignore
             _l_ratio,
@@ -418,10 +415,9 @@ class DataFrame(pd.DataFrame):
         **kwargs: Unpack[LMomentOptions],
     ) -> 'pd.Series[float]':
         """
-        See [`lmo.l_skew`][lmo.l_skew].
-
-        Returns:
-            out: A [`Series[float]`][pandas.Series].
+        Alias for
+        [`l_ratio(3, 2, ...)`][lmo.contrib.pandas.DataFrame.l_ratio].
+        See [`lmo.l_skew`][lmo.l_skew] for details.
         """
         return self.apply(  # type: ignore
             _l_ratio,
@@ -437,12 +433,9 @@ class DataFrame(pd.DataFrame):
         **kwargs: Unpack[LMomentOptions],
     ) -> 'pd.Series[float]':
         """
-        See [`lmo.l_kurtosis`][lmo.l_kurtosis].
-
-        The alias `l_kurt` is also available.
-
-        Returns:
-            out: A [`Series[float]`][pandas.Series].
+        Alias for
+        [`l_ratio(4, 2, ...)`][lmo.contrib.pandas.DataFrame.l_ratio].
+        See [`lmo.l_kurtosis`][lmo.l_kurtosis] for details.
         """
         return self.apply(  # type: ignore
             _l_ratio,
@@ -451,7 +444,17 @@ class DataFrame(pd.DataFrame):
             **kwargs,
         )
 
-    l_kurt = l_kurtosis
+    def l_kurt(
+        self,
+        trim: AnyTrim = (0, 0),
+        axis: AxisDF = 0,
+        **kwargs: Unpack[LMomentOptions],
+    ) -> 'pd.Series[float]':
+        """
+        Alias for
+        [`l_kurtosis`][lmo.contrib.pandas.DataFrame.l_kurtosis].
+        """
+        return self.l_kurtosis(trim=trim, axis=axis, **kwargs)
 
     def l_comoment(
         self,
@@ -535,11 +538,76 @@ class DataFrame(pd.DataFrame):
         out.attrs['l_trim'] = clean_trim(trim)
         return out
 
-    l_coloc = functools.partialmethod(l_comoment, 1)
-    l_coscale = functools.partialmethod(l_comoment, 2)
-    l_corr = functools.partialmethod(l_coratio, 2, 2)
-    l_coskew = functools.partialmethod(l_coratio, 3, 2)
-    l_cokurtosis = l_cokurt = functools.partialmethod(l_coratio, 4, 2)
+    def l_coloc(
+        self,
+        trim: AnyTrim = (0, 0),
+        **kwargs: Unpack[LComomentOptions],
+    ) -> pd.DataFrame:
+        """
+        Alias for [`l_comoment(1, trim, **kwargs)
+        `][lmo.contrib.pandas.DataFrame.l_comoment].
+        See [`lmo.l_coloc`][lmo.l_coloc] for details.
+        """
+        return self.l_comoment(1, trim=trim, **kwargs)
+
+    def l_coscale(
+        self,
+        trim: AnyTrim = (0, 0),
+        **kwargs: Unpack[LComomentOptions],
+    ) -> pd.DataFrame:
+        """
+        Alias for [`l_comoment(2, trim, **kwargs)
+        `][lmo.contrib.pandas.DataFrame.l_comoment].
+        See [`lmo.l_coscale`][lmo.l_coscale] for details.
+        """
+        return self.l_comoment(2, trim=trim, **kwargs)
+
+    def l_corr(
+        self,
+        trim: AnyTrim = (0, 0),
+        **kwargs: Unpack[LComomentOptions],
+    ) -> pd.DataFrame:
+        """
+        Alias for [`l_coratio(2, 2, trim, **kwargs)
+        `][lmo.contrib.pandas.DataFrame.l_coratio].
+        See [`lmo.l_corr`][lmo.l_corr] for details.
+        """
+        return self.l_coratio(2, trim=trim, **kwargs)
+
+    def l_coskew(
+        self,
+        trim: AnyTrim = (0, 0),
+        **kwargs: Unpack[LComomentOptions],
+    ) -> pd.DataFrame:
+        """
+        Alias for [`l_coratio(3, 2, trim, **kwargs)
+        `][lmo.contrib.pandas.DataFrame.l_coratio].
+        See [`lmo.l_coskew`][lmo.l_coskew] for details.
+        """
+        return self.l_coratio(3, trim=trim, **kwargs)
+
+    def l_cokurtosis(
+        self,
+        trim: AnyTrim = (0, 0),
+        **kwargs: Unpack[LComomentOptions],
+    ) -> pd.DataFrame:
+        """
+        Alias for [`l_coratio(4, 2, trim, **kwargs)
+        `][lmo.contrib.pandas.DataFrame.l_coratio].
+        See [`lmo.l_cokurtosis`][lmo.l_cokurtosis] for details.
+        """
+        return self.l_coratio(4, trim=trim, **kwargs)
+
+    def l_cokurt(
+        self,
+        trim: AnyTrim = (0, 0),
+        **kwargs: Unpack[LComomentOptions],
+    ) -> pd.DataFrame:
+        """
+        Alias for
+        [`l_cokurtosis`][lmo.contrib.pandas.DataFrame.l_cokurtosis].
+        """
+        return self.l_cokurtosis(trim=trim, **kwargs)
 
 
 class _Registerable(Protocol):

--- a/lmo/contrib/pandas.py
+++ b/lmo/contrib/pandas.py
@@ -10,14 +10,14 @@ Examples:
     ```pycon
     >>> df = pd.DataFrame({'a': [1, 2, 2, 3, 4], 'b': [3, 4, 4, 4, 4]})
     >>> df.l_stats()
-            a    b
+              a    b
     r
     1  2.400000  3.8
     2  0.700000  0.2
     3  0.142857 -1.0
     4  0.285714  1.0
     >>> df.aggregate(['mean', 'std', 'skew', 'kurt'])
-                a         b
+                 a         b
     mean  2.400000  3.800000
     std   1.140175  0.447214
     skew  0.404796 -2.236068
@@ -29,11 +29,11 @@ Examples:
     ```pycon
     >>> df = pd.DataFrame({'dogs': [.2, .0, .5, .4], 'cats': [.3, .2, .0, .1]})
     >>> df.l_corr()
-        dogs      cats
+          dogs      cats
     dogs   1.0 -0.764706
     cats  -0.8  1.000000
     >>> df.corr()
-            dogs      cats
+              dogs      cats
     dogs  1.000000 -0.756889
     cats -0.756889  1.000000
     ```

--- a/lmo/contrib/pandas.py
+++ b/lmo/contrib/pandas.py
@@ -10,7 +10,6 @@ __all__ = (
     'install',
 )
 
-import functools
 import sys
 from collections.abc import Callable
 from typing import (
@@ -612,15 +611,15 @@ class DataFrame(pd.DataFrame):
 
 class _Registerable(Protocol):
     @staticmethod
-    def __lmo_register__(name: str, method: Callable[..., Any]) -> None: ...
+    def __lmo_register__(
+        name: str,
+        method: Callable[..., Any],
+    ) -> None: ...
 
 
 def _register_methods(cls: type[_Registerable]):
     for k, method in cls.__dict__.items():
-        if not k.startswith('_') and (
-            callable(method)
-            or isinstance(method, functools.partialmethod)
-        ):
+        if not k.startswith('_') and callable(method):
             cls.__lmo_register__(k, method)
 
 

--- a/lmo/contrib/pandas.py
+++ b/lmo/contrib/pandas.py
@@ -22,6 +22,7 @@ Examples:
     std   1.140175  0.447214
     skew  0.404796 -2.236068
     kurt -0.177515  5.000000
+
     ```
 
     Comparison of L-correlation, and Pearson correlation matrices:
@@ -36,6 +37,7 @@ Examples:
               dogs      cats
     dogs  1.000000 -0.756889
     cats -0.756889  1.000000
+
     ```
 """
 __all__ = (

--- a/lmo/contrib/pandas.py
+++ b/lmo/contrib/pandas.py
@@ -123,7 +123,7 @@ class Series(pd.Series):  # type: ignore [missingTypeArguments]
 
         Returns:
             out: A scalar, or [`pd.Series[float]`][pandas.Series], with a
-            [`MultiIndex`][pandas.MultiIndex] of `r` and `k`.
+                [`MultiIndex`][pandas.MultiIndex] of `r` and `k`.
         """
         rk = broadstack(r, k)
         out = moments_to_ratio(rk, _l_moment(self, rk, trim=trim, **kwargs))
@@ -147,13 +147,82 @@ class Series(pd.Series):  # type: ignore [missingTypeArguments]
         See [`lmo.l_stats`][lmo.l_stats].
 
         Returns:
-            A [`pd.Series[float]`][pandas.Series] with index `r = 1, ..., num`.
+            out: A [`pd.Series[float]`][pandas.Series] with index
+                `r = 1, ..., num`.
         """
         return pd.Series(
             _l_stats(self, trim=trim, num=num, **kwargs),
             index=pd.RangeIndex(1, num + 1, name='r'),
             copy=False,
         )
+
+    def l_loc(
+        self,
+        trim: AnyTrim = (0, 0),
+        **kwargs: Unpack[LMomentOptions],
+    ) -> float:
+        """
+        See [`lmo.l_loc`][lmo.l_loc].
+
+        Returns:
+            out: A scalar.
+        """
+        return cast(float, _l_moment(self, 1, trim, **kwargs))
+
+    def l_scale(
+        self,
+        trim: AnyTrim = (0, 0),
+        **kwargs: Unpack[LMomentOptions],
+    ) -> float:
+        """
+        See [`lmo.l_scale`][lmo.l_scale].
+
+        Returns:
+            out: A scalar.
+        """
+        return cast(float, _l_moment(self, 2, trim, **kwargs))
+
+    def l_variation(
+        self,
+        trim: AnyTrim = (0, 0),
+        **kwargs: Unpack[LMomentOptions],
+    ) -> float:
+        """
+        See [`lmo.l_variation`][lmo.l_variation].
+
+        Returns:
+            out: A scalar.
+        """
+        return cast(float, _l_ratio(self, 2, 1, trim, **kwargs))
+
+    def l_skew(
+        self,
+        trim: AnyTrim = (0, 0),
+        **kwargs: Unpack[LMomentOptions],
+    ) -> float:
+        """
+        See [`lmo.l_skew`][lmo.l_skew].
+
+        Returns:
+            out: A scalar.
+        """
+        return cast(float, _l_ratio(self, 3, 2, trim, **kwargs))
+
+    def l_kurtosis(
+        self,
+        trim: AnyTrim = (0, 0),
+        **kwargs: Unpack[LMomentOptions],
+    ) -> float:
+        """
+        See [`lmo.l_kurtosis`][lmo.l_kurtosis].
+
+        Returns:
+            out: A scalar.
+        """
+        return cast(float, _l_ratio(self, 4, 2, trim, **kwargs))
+
+    l_kurt = l_kurtosis
+
 
 @final
 class DataFrame(pd.DataFrame):
@@ -273,6 +342,103 @@ class DataFrame(pd.DataFrame):
         out.attrs['l_kind'] = 'stat'
         out.attrs['l_trim'] = clean_trim(trim)
         return out
+
+    def l_loc(
+        self,
+        trim: AnyTrim = (0, 0),
+        axis: AxisDF = 0,
+        **kwargs: Unpack[LMomentOptions],
+    ) -> 'pd.Series[float]':
+        """
+        See [`lmo.l_loc`][lmo.l_loc].
+
+        Returns:
+            out: A [`Series[float]`][pandas.Series].
+        """
+        return self.apply(  # type: ignore
+            _l_moment,
+            axis=axis,
+            args=(1, trim),
+            **kwargs,
+        )
+
+    def l_scale(
+        self,
+        trim: AnyTrim = (0, 0),
+        axis: AxisDF = 0,
+        **kwargs: Unpack[LMomentOptions],
+    ) -> 'pd.Series[float]':
+        """
+        See [`lmo.l_scale`][lmo.l_scale].
+
+        Returns:
+            out: A [`Series[float]`][pandas.Series].
+        """
+        return self.apply(  # type: ignore
+            _l_moment,
+            axis=axis,
+            args=(2, trim),
+            **kwargs,
+        )
+
+    def l_variation(
+        self,
+        trim: AnyTrim = (0, 0),
+        axis: AxisDF = 0,
+        **kwargs: Unpack[LMomentOptions],
+    ) -> 'pd.Series[float]':
+        """
+        See [`lmo.l_variation`][lmo.l_variation].
+
+        Returns:
+            out: A [`Series[float]`][pandas.Series].
+        """
+        return self.apply(  # type: ignore
+            _l_ratio,
+            axis=axis,
+            args=(2, 1, trim),
+            **kwargs,
+        )
+
+    def l_skew(
+        self,
+        trim: AnyTrim = (0, 0),
+        axis: AxisDF = 0,
+        **kwargs: Unpack[LMomentOptions],
+    ) -> 'pd.Series[float]':
+        """
+        See [`lmo.l_skew`][lmo.l_skew].
+
+        Returns:
+            out: A [`Series[float]`][pandas.Series].
+        """
+        return self.apply(  # type: ignore
+            _l_ratio,
+            axis=axis,
+            args=(3, 2, trim),
+            **kwargs,
+        )
+
+    def l_kurtosis(
+        self,
+        trim: AnyTrim = (0, 0),
+        axis: AxisDF = 0,
+        **kwargs: Unpack[LMomentOptions],
+    ) -> 'pd.Series[float]':
+        """
+        See [`lmo.l_kurtosis`][lmo.l_kurtosis].
+
+        Returns:
+            out: A [`Series[float]`][pandas.Series].
+        """
+        return self.apply(  # type: ignore
+            _l_ratio,
+            axis=axis,
+            args=(4, 2, trim),
+            **kwargs,
+        )
+
+    l_kurt = l_kurtosis
 
 
 class _Registerable(Protocol):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,10 @@
 site_name: Lmo
-site_description: Robust statistics with generalized trimmed L-Moments.
+site_description: Robust stats and fitting using (trimmed) L-Moments
 site_author: Joren Hammudoglu
-site_url: https://jorenham.github.io/lmo
+site_url: https://jorenham.github.io/Lmo/
 
-repo_name: jorenham/lmo
-repo_url: https://github.com/jorenham/lmo
+repo_name: jorenham/Lmo
+repo_url: https://github.com/jorenham/Lmo/
 
 strict: true
 
@@ -44,7 +44,7 @@ plugins:
           options:
             annotations_path: 'source'
             docstring_section_style: 'spacy'
-            line_length: 80
+            line_length: 79
             load_external_modules: true
             members_order: source
             merge_init_into_class: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ plugins:
           import:
             - url: https://numpy.org/doc/stable/objects.inv
             - url: https://docs.scipy.org/doc/scipy/objects.inv
+            - url: https://pandas.pydata.org/docs/objects.inv
           options:
             annotations_path: 'source'
             docstring_section_style: 'spacy'

--- a/poetry.lock
+++ b/poetry.lock
@@ -1335,6 +1335,74 @@ files = [
 ]
 
 [[package]]
+name = "pandas"
+version = "2.1.2"
+description = "Powerful data structures for data analysis, time series, and statistics"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pandas-2.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:24057459f19db9ebb02984c6fdd164a970b31a95f38e4a49cf7615b36a1b532c"},
+    {file = "pandas-2.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a6cf8fcc8a63d333970b950a7331a30544cf59b1a97baf0a7409e09eafc1ac38"},
+    {file = "pandas-2.1.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ae6ffbd9d614c20d028c7117ee911fc4e266b4dca2065d5c5909e401f8ff683"},
+    {file = "pandas-2.1.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eff794eeb7883c5aefb1ed572e7ff533ae779f6c6277849eab9e77986e352688"},
+    {file = "pandas-2.1.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:02954e285e8e2f4006b6f22be6f0df1f1c3c97adbb7ed211c6b483426f20d5c8"},
+    {file = "pandas-2.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:5b40c9f494e1f27588c369b9e4a6ca19cd924b3a0e1ef9ef1a8e30a07a438f43"},
+    {file = "pandas-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:08d287b68fd28906a94564f15118a7ca8c242e50ae7f8bd91130c362b2108a81"},
+    {file = "pandas-2.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bbd98dcdcd32f408947afdb3f7434fade6edd408c3077bbce7bd840d654d92c6"},
+    {file = "pandas-2.1.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e90c95abb3285d06f6e4feedafc134306a8eced93cb78e08cf50e224d5ce22e2"},
+    {file = "pandas-2.1.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:52867d69a54e71666cd184b04e839cff7dfc8ed0cd6b936995117fdae8790b69"},
+    {file = "pandas-2.1.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8d0382645ede2fde352da2a885aac28ec37d38587864c0689b4b2361d17b1d4c"},
+    {file = "pandas-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:65177d1c519b55e5b7f094c660ed357bb7d86e799686bb71653b8a4803d8ff0d"},
+    {file = "pandas-2.1.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:5aa6b86802e8cf7716bf4b4b5a3c99b12d34e9c6a9d06dad254447a620437931"},
+    {file = "pandas-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d594e2ce51b8e0b4074e6644758865dc2bb13fd654450c1eae51201260a539f1"},
+    {file = "pandas-2.1.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3223f997b6d2ebf9c010260cf3d889848a93f5d22bb4d14cd32638b3d8bba7ad"},
+    {file = "pandas-2.1.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc4944dc004ca6cc701dfa19afb8bdb26ad36b9bed5bcec617d2a11e9cae6902"},
+    {file = "pandas-2.1.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3f76280ce8ec216dde336e55b2b82e883401cf466da0fe3be317c03fb8ee7c7d"},
+    {file = "pandas-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:7ad20d24acf3a0042512b7e8d8fdc2e827126ed519d6bd1ed8e6c14ec8a2c813"},
+    {file = "pandas-2.1.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:021f09c15e1381e202d95d4a21ece8e7f2bf1388b6d7e9cae09dfe27bd2043d1"},
+    {file = "pandas-2.1.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e7f12b2de0060b0b858cfec0016e7d980ae5bae455a1746bfcc70929100ee633"},
+    {file = "pandas-2.1.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83c166b9bb27c1715bed94495d9598a7f02950b4749dba9349c1dd2cbf10729d"},
+    {file = "pandas-2.1.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:25c9976c17311388fcd953cb3d0697999b2205333f4e11e669d90ff8d830d429"},
+    {file = "pandas-2.1.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:851b5afbb0d62f6129ae891b533aa508cc357d5892c240c91933d945fff15731"},
+    {file = "pandas-2.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:e78507adcc730533619de07bfdd1c62b2918a68cd4419ea386e28abf7f6a1e5c"},
+    {file = "pandas-2.1.2.tar.gz", hash = "sha256:52897edc2774d2779fbeb6880d2cfb305daa0b1a29c16b91f531a18918a6e0f3"},
+]
+
+[package.dependencies]
+numpy = [
+    {version = ">=1.22.4,<2", markers = "python_version < \"3.11\""},
+    {version = ">=1.23.2,<2", markers = "python_version == \"3.11\""},
+    {version = ">=1.26.0,<2", markers = "python_version >= \"3.12\""},
+]
+python-dateutil = ">=2.8.2"
+pytz = ">=2020.1"
+tzdata = ">=2022.1"
+
+[package.extras]
+all = ["PyQt5 (>=5.15.6)", "SQLAlchemy (>=1.4.36)", "beautifulsoup4 (>=4.11.1)", "bottleneck (>=1.3.4)", "dataframe-api-compat (>=0.1.7)", "fastparquet (>=0.8.1)", "fsspec (>=2022.05.0)", "gcsfs (>=2022.05.0)", "html5lib (>=1.1)", "hypothesis (>=6.46.1)", "jinja2 (>=3.1.2)", "lxml (>=4.8.0)", "matplotlib (>=3.6.1)", "numba (>=0.55.2)", "numexpr (>=2.8.0)", "odfpy (>=1.4.1)", "openpyxl (>=3.0.10)", "pandas-gbq (>=0.17.5)", "psycopg2 (>=2.9.3)", "pyarrow (>=7.0.0)", "pymysql (>=1.0.2)", "pyreadstat (>=1.1.5)", "pytest (>=7.3.2)", "pytest-asyncio (>=0.17.0)", "pytest-xdist (>=2.2.0)", "pyxlsb (>=1.0.9)", "qtpy (>=2.2.0)", "s3fs (>=2022.05.0)", "scipy (>=1.8.1)", "tables (>=3.7.0)", "tabulate (>=0.8.10)", "xarray (>=2022.03.0)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.0.3)", "zstandard (>=0.17.0)"]
+aws = ["s3fs (>=2022.05.0)"]
+clipboard = ["PyQt5 (>=5.15.6)", "qtpy (>=2.2.0)"]
+compression = ["zstandard (>=0.17.0)"]
+computation = ["scipy (>=1.8.1)", "xarray (>=2022.03.0)"]
+consortium-standard = ["dataframe-api-compat (>=0.1.7)"]
+excel = ["odfpy (>=1.4.1)", "openpyxl (>=3.0.10)", "pyxlsb (>=1.0.9)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.0.3)"]
+feather = ["pyarrow (>=7.0.0)"]
+fss = ["fsspec (>=2022.05.0)"]
+gcp = ["gcsfs (>=2022.05.0)", "pandas-gbq (>=0.17.5)"]
+hdf5 = ["tables (>=3.7.0)"]
+html = ["beautifulsoup4 (>=4.11.1)", "html5lib (>=1.1)", "lxml (>=4.8.0)"]
+mysql = ["SQLAlchemy (>=1.4.36)", "pymysql (>=1.0.2)"]
+output-formatting = ["jinja2 (>=3.1.2)", "tabulate (>=0.8.10)"]
+parquet = ["pyarrow (>=7.0.0)"]
+performance = ["bottleneck (>=1.3.4)", "numba (>=0.55.2)", "numexpr (>=2.8.0)"]
+plot = ["matplotlib (>=3.6.1)"]
+postgresql = ["SQLAlchemy (>=1.4.36)", "psycopg2 (>=2.9.3)"]
+spss = ["pyreadstat (>=1.1.5)"]
+sql-other = ["SQLAlchemy (>=1.4.36)"]
+test = ["hypothesis (>=6.46.1)", "pytest (>=7.3.2)", "pytest-asyncio (>=0.17.0)", "pytest-xdist (>=2.2.0)"]
+xml = ["lxml (>=4.8.0)"]
+
+[[package]]
 name = "parso"
 version = "0.8.3"
 description = "A Python Parser"
@@ -1659,6 +1727,17 @@ files = [
 
 [package.dependencies]
 six = ">=1.5"
+
+[[package]]
+name = "pytz"
+version = "2023.3.post1"
+description = "World timezone definitions, modern and historical"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pytz-2023.3.post1-py2.py3-none-any.whl", hash = "sha256:ce42d816b81b68506614c11e8937d3aa9e41007ceb50bfdcb0749b921bf646c7"},
+    {file = "pytz-2023.3.post1.tar.gz", hash = "sha256:7b4fddbeb94a1eba4b557da24f19fdf9db575192544270a9101d8509f9f43d7b"},
+]
 
 [[package]]
 name = "pywin32"
@@ -2184,6 +2263,17 @@ files = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2023.3"
+description = "Provider of IANA time zone data"
+optional = false
+python-versions = ">=2"
+files = [
+    {file = "tzdata-2023.3-py2.py3-none-any.whl", hash = "sha256:7e65763eef3120314099b6939b5546db7adce1e7d6f2e179e3df563c70511eda"},
+    {file = "tzdata-2023.3.tar.gz", hash = "sha256:11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a"},
+]
+
+[[package]]
 name = "urllib3"
 version = "2.0.7"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -2267,4 +2357,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "d1fe4f7697ab203c426034ea74fe10abb67ee8bb0b9ebdf0ab9ff7f1e1c97bdf"
+content-hash = "70e00ad62d0c36c5be3d29803940ed3e1a6fe291a157d1ec0eb9d8aa31177383"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1403,6 +1403,21 @@ test = ["hypothesis (>=6.46.1)", "pytest (>=7.3.2)", "pytest-asyncio (>=0.17.0)"
 xml = ["lxml (>=4.8.0)"]
 
 [[package]]
+name = "pandas-stubs"
+version = "2.1.1.230928"
+description = "Type annotations for pandas"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pandas_stubs-2.1.1.230928-py3-none-any.whl", hash = "sha256:992d97159e054ca3175ebe8321ac5616cf6502dd8218b03bb0eaf3c4f6939037"},
+    {file = "pandas_stubs-2.1.1.230928.tar.gz", hash = "sha256:ce1691c71c5d67b8f332da87763f7f54650f46895d99964d588c3a5d79e2cacc"},
+]
+
+[package.dependencies]
+numpy = {version = ">=1.26.0", markers = "python_version < \"3.13\""}
+types-pytz = ">=2022.1.1"
+
+[[package]]
 name = "parso"
 version = "0.8.3"
 description = "A Python Parser"
@@ -2252,6 +2267,17 @@ docs = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
 test = ["argcomplete (>=3.0.3)", "mypy (>=1.6.0)", "pre-commit", "pytest (>=7.0,<7.5)", "pytest-mock", "pytest-mypy-testing"]
 
 [[package]]
+name = "types-pytz"
+version = "2023.3.1.1"
+description = "Typing stubs for pytz"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-pytz-2023.3.1.1.tar.gz", hash = "sha256:cc23d0192cd49c8f6bba44ee0c81e4586a8f30204970fc0894d209a6b08dab9a"},
+    {file = "types_pytz-2023.3.1.1-py3-none-any.whl", hash = "sha256:1999a123a3dc0e39a2ef6d19f3f8584211de9e6a77fe7a0259f04a524e90a5cf"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.8.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -2354,7 +2380,10 @@ files = [
     {file = "wcwidth-0.2.8.tar.gz", hash = "sha256:8705c569999ffbb4f6a87c6d1b80f324bd6db952f5eb0b95bc07517f4c1813d4"},
 ]
 
+[extras]
+pandas = ["pandas"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "70e00ad62d0c36c5be3d29803940ed3e1a6fe291a157d1ec0eb9d8aa31177383"
+content-hash = "71716eda44ba0808580e0e6af4691e03b9115972996c275390bdd355e2bcf350"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,10 @@ mkdocstrings = {extras = ["python"], version = ">=0.23,<1.0"}
 ipython = "^8.16"
 ipykernel = "^6.25"
 matplotlib = "^3.8"
-
 line-profiler = "^4.1"
 
+[tool.poetry.group.contrib.dependencies]
+pandas = ">=1.4"
 
 [tool.pytest.ini_options]
 minversion = "7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,15 +33,16 @@ Documentation = "https://jorenham.github.io/lmo/"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"
+typing_extensions = { version = "^4.1", python = "<3.11"}
 numpy = "^1.22.4"
 scipy = "^1.9"
-typing_extensions = { version = "^4.1", python = "<3.11"}
+pandas = { version = ">=1.4", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4"
 hypothesis = { extras = ["numpy"], version = "^6.88" }
 pyright = "^1.1"
-ruff = ">=0.1.1,<1.0"
+ruff = ">=0.1.3,<1.0"
 codespell = "^2.2"
 
 [tool.poetry.group.docs.dependencies]
@@ -56,8 +57,12 @@ ipykernel = "^6.25"
 matplotlib = "^3.8"
 line-profiler = "^4.1"
 
-[tool.poetry.group.contrib.dependencies]
+[tool.poetry.group.pandas.dependencies]
 pandas = ">=1.4"
+pandas-stubs = ">=1.4"
+
+[tool.poetry.extras]
+pandas = ["pandas"]
 
 [tool.pytest.ini_options]
 minversion = "7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,10 +68,13 @@ pandas = ["pandas"]
 minversion = "7.0"
 addopts = [
     "-ra",
+    "--exitfirst",
+    "--import-mode=importlib",
     "--showlocals",
     "--strict-markers",
     "--strict-config",
     "--doctest-modules",
+    "--doctest-ignore-import-errors",
 ]
 doctest_optionflags = [
     "NORMALIZE_WHITESPACE",
@@ -79,7 +82,11 @@ doctest_optionflags = [
     "ELLIPSIS",
 ]
 xfail_strict = true
-filterwarnings = ["error"]
+filterwarnings = [
+    "error",
+    # https://github.com/dateutil/dateutil/issues/1314
+    "ignore::DeprecationWarning:dateutil",
+]
 log_cli_level = "info"
 testpaths = ["tests", "lmo"]
 
@@ -99,6 +106,10 @@ exclude = [
     "docs",
     "site",
     "tests",
+]
+ignore = [
+    # TODO: figure out how to do this conditionally
+    "lmo/contrib/pandas.py",
 ]
 venv = ".venv"
 pythonVersion = "3.10"


### PR DESCRIPTION
Most `lmo.l_*` functions are now available as  `pandas.Series` and `pandas.DataFrame` (accessor) methods.

 Whereas the `lmo.l_*` functions return numpy arrays (or scalars), the new methods return properly-indexed `Series` or `DataFrame` instances.
Also, the univariate `DataFrame` methods accept pandas-style axis parameters, e.g. `axis='index` or `axis='columns` , as alias for `axis=0` or `axis=1`, respectively.

## Examples

Univariate summary statistics:

```pycon
>>> df = pd.DataFrame({'a': [1, 2, 2, 3, 4], 'b': [3, 4, 4, 4, 4]})
>>> df.l_stats()
        a    b
r
1  2.400000  3.8
2  0.700000  0.2
3  0.142857 -1.0
4  0.285714  1.0
>>> df.aggregate(['mean', 'std', 'skew', 'kurt'])
            a         b
mean  2.400000  3.800000
std   1.140175  0.447214
skew  0.404796 -2.236068
kurt -0.177515  5.000000
```

Comparison of L-correlation, and Pearson correlation matrices:

```pycon
>>> df = pd.DataFrame({'dogs': [.2, .0, .5, .4], 'cats': [.3, .2, .0, .1]})
>>> df.l_corr()
    dogs      cats
dogs   1.0 -0.764706
cats  -0.8  1.000000
>>> df.corr()
        dogs      cats
dogs  1.000000 -0.756889
cats -0.756889  1.000000
```