### PR TITLE
changed default sorting method from `'stable'` to `None`, i.e. `'quicksort'` (which actually is introsort)

### DIFF
--- a/lmo/_lm.py
+++ b/lmo/_lm.py
@@ -332,7 +332,7 @@ def l_moment(
     dtype: np.dtype[T] | type[T] = np.float64,
     fweights: IntVector | None = None,
     aweights: npt.ArrayLike | None = None,
-    sort: SortKind | None = 'stable',
+    sort: SortKind | None = None,
     cache: bool = False,
 ) -> npt.NDArray[T] | T:
     r"""
@@ -1058,7 +1058,7 @@ def l_moment_influence(
     /,
     trim: AnyTrim = (0, 0),
     *,
-    sort: SortKind | None = 'stable',
+    sort: SortKind | None = None,
     tol: float = 1e-8,
 ) -> Callable[[V], V]:
     r"""
@@ -1124,7 +1124,7 @@ def l_ratio_influence(
     /,
     trim: AnyTrim = (0, 0),
     *,
-    sort: SortKind | None = 'stable',
+    sort: SortKind | None = None,
     tol: float = 1e-8,
 ) -> Callable[[V], V]:
     r"""
@@ -1151,7 +1151,7 @@ def l_ratio_influence(
             The (vectorized) empirical influence function.
 
     """
-    _x = np.sort(a, kind=sort)
+    _x = np.sort(a, kind=sort)  # type: ignore
     _r, _k = clean_order(r), clean_order(k)
     n = len(_x)
 

--- a/lmo/_lm_co.py
+++ b/lmo/_lm_co.py
@@ -35,7 +35,7 @@ def l_comoment(
     *,
     dtype: np.dtype[T] | type[T] = np.float64,
     rowvar: bool = True,
-    sort: SortKind | None = 'stable',
+    sort: SortKind | None = None,
     cache: bool = False,
 ) -> npt.NDArray[T]:
     r"""

--- a/lmo/_utils.py
+++ b/lmo/_utils.py
@@ -140,7 +140,7 @@ def ordered(
     *,
     fweights: IntVector | None = None,
     aweights: npt.ArrayLike | None = None,
-    sort: SortKind | None = 'stable',
+    sort: SortKind | None = None,
 ) -> npt.NDArray[np.floating[Any]]:
     """
     Calculate `n = len(x)` order stats of `x`, optionally weighted.
@@ -165,12 +165,12 @@ def ordered(
     _x = _clean_array(x)
 
     if aweights is None and y is None:
-        return np.sort(_x, axis=axis, kind=sort)
+        return np.sort(_x, axis=axis, kind=sort)  # type: ignore
     if y is not None:
         _y = _clean_array(y)
         i_k = np.argsort(_y, axis=axis if _y.ndim > 1 else -1, kind=sort)
     else:
-        i_k = np.argsort(_x, axis=axis, kind=sort)
+        i_k = np.argsort(_x, axis=axis, kind=sort)  # type: ignore
 
     def _sort_like(a: npt.NDArray[T]) -> npt.NDArray[T]:
         return (


### PR DESCRIPTION
As stated in https://numpy.org/doc/stable/reference/generated/numpy.sort.html, NumPy replaces quicksort with introsort in 1.17, which is `O(n log(n))`, just like stablesort. This is the default algorithm, i.e. used when `np.sort(..., kind=None)`.
Since Lmo generally deals with i.i.d. samples, stablesort also has no practical advantage over introsort, hence making it a better default for Lmo.