### PR TITLE
Prevent `IntegerOverflow` on windows: prefer `np.int64` over `np.int_`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   ci:
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     strategy:
       fail-fast: false

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,8 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # os: [ubuntu-latest, windows-latest]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ['3.10', '3.12']
         pandas: ['without', 'with']
 

--- a/lmo/_distns.py
+++ b/lmo/_distns.py
@@ -49,7 +49,7 @@ def _check_lmoments(l_r: npt.NDArray[np.floating[Any]], s: float, t: float):
     if n == 2:
         return
 
-    r = np.arange(1, n + 1, dtype=np.int_)
+    r = np.arange(1, n + 1)
     t_r = l_r[2:] / l_r[1]
     t_r_max = l_ratio_bounds(r[2:], (s, t))
     if np.any(rs0_oob := np.abs(t_r) > t_r_max):

--- a/lmo/_lm.py
+++ b/lmo/_lm.py
@@ -70,7 +70,7 @@ def _l_weights_pwm(
     s, t = trim
     r0 = r + s + t
 
-    p0 = sh_legendre(r0, dtype=np.int_ if r0 < 29 else dtype)
+    p0 = sh_legendre(r0, dtype=np.int64 if r0 < 29 else dtype)
     w0 = p0 @ pwm_beta.weights(r0, n, dtype=dtype)  # type: ignore
     out = trim_matrix(r, trim, dtype=dtype) @ w0 if s or t else w0
     return cast(npt.NDArray[T], out)

--- a/lmo/_utils.py
+++ b/lmo/_utils.py
@@ -51,7 +51,7 @@ def as_float_array(
 def broadstack(
     r: AnyInt | IntVector,
     s: AnyInt | IntVector,
-) -> npt.NDArray[np.int_]:
+) -> npt.NDArray[np.int64]:
     return np.stack(np.broadcast_arrays(np.asarray(r), np.asarray(s)))
 
 
@@ -210,8 +210,8 @@ def clean_orders(
     /,
     name: str = 'r',
     rmin: int = 0,
-) -> npt.NDArray[np.int_]:
-    _r = np.asarray_chkfinite(r, np.int_)
+) -> npt.NDArray[np.int64]:
+    _r = np.asarray_chkfinite(r, np.int64)
 
     if np.any(invalid := _r < rmin):
         i = np.argmax(invalid)
@@ -308,7 +308,7 @@ def moments_to_stats_cov(
 def l_stats_orders(
     num: int,
     /,
-) -> tuple[npt.NDArray[np.int_], npt.NDArray[np.int_]]:
+) -> tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]:
     return (
         np.arange(1, num + 1),
         np.array([0] * min(2, num) + [2] * (num - 2)),

--- a/lmo/linalg.py
+++ b/lmo/linalg.py
@@ -92,12 +92,12 @@ def pascal(
     Examples:
         >>> import numpy as np
         >>> from lmo.linalg import pascal
-        >>> pascal(4)
+        >>> pascal(4, dtype=np.int_)
         array([[1, 0, 0, 0],
                [1, 1, 0, 0],
                [1, 2, 1, 0],
                [1, 3, 3, 1]])
-        >>> pascal(4, inv=True)
+        >>> pascal(4, dtype=np.int_, inv=True)
         array([[ 1,  0,  0,  0],
                [-1,  1,  0,  0],
                [ 1, -2,  1,  0],

--- a/lmo/linalg.py
+++ b/lmo/linalg.py
@@ -247,7 +247,7 @@ def sh_legendre(
         Calculate $\widetilde{P}_{4 \times 4}$:
 
         >>> from lmo.linalg import sh_legendre
-        >>> sh_legendre(4)
+        >>> sh_legendre(4, dtype=int)
         array([[  1,   0,   0,   0],
                [ -1,   2,   0,   0],
                [  1,  -6,   6,   0],
@@ -296,7 +296,7 @@ def sh_jacobi(
         Calculate $\widetilde{P}^{(1, 1)}_{4 \times 4}$:
 
         >>> from lmo.linalg import sh_jacobi
-        >>> sh_jacobi(4, 1, 1)
+        >>> sh_jacobi(4, 1, 1, dtype=int)
         array([[  1,   0,   0,   0],
                [ -2,   4,   0,   0],
                [  3, -15,  15,   0],
@@ -349,19 +349,26 @@ def succession_matrix(c: npt.NDArray[T], /) -> npt.NDArray[T]:
 
     Examples:
         >>> from lmo.linalg import succession_matrix
-        >>> succession_matrix(np.arange(1, 9).reshape(4, 2))
+        >>> c = np.arange(1, 9).reshape(4, 2)
+        >>> c
+        array([[1, 2],
+               [3, 4],
+               [5, 6],
+               [7, 8]])
+        >>> succession_matrix(c)
         array([[1, 2, 0, 0, 0],
                [0, 3, 4, 0, 0],
                [0, 0, 5, 6, 0],
                [0, 0, 0, 7, 8]])
     """
-    n, k = np.atleast_1d(c).shape
-    i = np.linspace(0, n - 1, n, dtype=np.int64)
+    _c = np.atleast_2d(c)
 
-    out = np.zeros((n, n + k - 1), dtype=c.dtype)
+    n, k = _c.shape
+    i = np.arange(n)
+
+    out = np.zeros((n, n + k - 1), dtype=_c.dtype)
     for d in range(k):
-        out[i, i + d] = c[:, d]
-
+        out[i, i + d] = _c[:, d]
     return out
 
 

--- a/lmo/linalg.py
+++ b/lmo/linalg.py
@@ -111,7 +111,7 @@ def pascal(
         Now, let's compare with scipy:
 
         >>> from scipy.linalg import invpascal
-        >>> invpascal(4, kind='lower')
+        >>> invpascal(4, kind='lower').astype(int)
         array([[ 1,  0,  0,  0],
                [-1,  1,  0,  0],
                [ 1, -2,  1,  0],

--- a/lmo/pwm_beta.py
+++ b/lmo/pwm_beta.py
@@ -127,7 +127,7 @@ def cov(
     #     for j in range(i + 1, n)
     # ) / n^(k+l+2)
     for k in range(r):
-        j_k = np.arange(-k, n - k - 1)  # pyright: ignore
+        j_k = np.arange(-k, n - k - 1)
         v_ki = np.empty(x.shape, dtype=dtype)
         for i in range(n):
             # sum(
@@ -148,8 +148,8 @@ def cov(
     #     for j in range(i + 1, n)
     # ) / n^(k+l+2)
     for k, m in zip(*np.tril_indices(r, -1), strict=True):
-        j_k: npt.NDArray[np.int_] = np.arange(-k, n - k - 1)  # pyright: ignore
-        j_l: npt.NDArray[np.int_] = np.arange(-m, n - m - 1)  # pyright: ignore
+        j_k = np.arange(-k, n - k - 1, dtype=int)
+        j_l = np.arange(-m, n - m - 1, dtype=int)
 
         v_ki = np.empty(x.shape, dtype=dtype)
         for i in range(n):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,7 +28,7 @@ theme:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/jorenham
+      link: https://github.com/jorenham/
 
 plugins:
   - include-markdown
@@ -58,13 +58,18 @@ plugins:
             signature_crossrefs: true
 
 markdown_extensions:
+  # https://python-markdown.github.io/extensions/
   - admonition
-  - footnotes
-  - pymdownx.highlight
-  - pymdownx.superfences
-  - pymdownx.betterem
+  - extra
+  - sane_lists
+  - smarty
+
+  # https://facelessuser.github.io/pymdown-extensions/
   - pymdownx.arithmatex:
       generic: true
+  - pymdownx.betterem
+  - pymdownx.highlight
+  - pymdownx.superfences
   - pymdownx.tasklist:
       custom_checkbox: true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,5 +218,5 @@ known-third-party = ["numpy", "pandas", "scipy"]
 
 
 [tool.codespell]
-skip = '*.lock,.venv,.vscode,dist,docs,site'
+skip = './dist,./site,.*.lock,*.pyc,*.js,*.css,*.svg,*.png,*.ico,*.ipynb'
 context = 2


### PR DESCRIPTION
fixes #58