### PR TITLE
Add missing `@overload`s for L-moment aliases

### DIFF
--- a/lmo/_lm.py
+++ b/lmo/_lm.py
@@ -682,6 +682,58 @@ def l_stats(
     return l_ratio(a, r, s, trim=trim, axis=axis, dtype=dtype, **kwargs)
 
 
+@overload
+def l_loc(
+    a: npt.ArrayLike,
+    /,
+    trim: AnyTrim = ...,
+    *,
+    axis: None = ...,
+    dtype: type[np.float64] = ...,
+    **kwargs: Unpack[LMomentOptions],
+) -> np.float64:
+    ...
+
+
+@overload
+def l_loc(
+    a: npt.ArrayLike,
+    /,
+    trim: AnyTrim = ...,
+    *,
+    axis: None = ...,
+    dtype: np.dtype[T] | type[T],
+    **kwargs: Unpack[LMomentOptions],
+) -> T:
+    ...
+
+
+@overload
+def l_loc(
+    a: npt.ArrayLike,
+    /,
+    trim: AnyTrim = ...,
+    *,
+    axis: int,
+    dtype: type[np.float64] = ...,
+    **kwargs: Unpack[LMomentOptions],
+) -> npt.NDArray[np.float64] | np.float64:
+    ...
+
+
+@overload
+def l_loc(
+    a: npt.ArrayLike,
+    /,
+    trim: AnyTrim = ...,
+    *,
+    axis: int,
+    dtype: np.dtype[T] | type[T],
+    **kwargs: Unpack[LMomentOptions],
+) -> npt.NDArray[T] | T:
+    ...
+
+
 def l_loc(
     a: npt.ArrayLike,
     /,
@@ -721,6 +773,58 @@ def l_loc(
     return l_moment(a, 1, trim, axis=axis, dtype=dtype, **kwargs)
 
 
+@overload
+def l_scale(
+    a: npt.ArrayLike,
+    /,
+    trim: AnyTrim = ...,
+    *,
+    axis: None = ...,
+    dtype: type[np.float64] = ...,
+    **kwargs: Unpack[LMomentOptions],
+) -> np.float64:
+    ...
+
+
+@overload
+def l_scale(
+    a: npt.ArrayLike,
+    /,
+    trim: AnyTrim = ...,
+    *,
+    axis: None = ...,
+    dtype: np.dtype[T] | type[T],
+    **kwargs: Unpack[LMomentOptions],
+) -> T:
+    ...
+
+
+@overload
+def l_scale(
+    a: npt.ArrayLike,
+    /,
+    trim: AnyTrim = ...,
+    *,
+    axis: int,
+    dtype: type[np.float64] = ...,
+    **kwargs: Unpack[LMomentOptions],
+) -> npt.NDArray[np.float64] | np.float64:
+    ...
+
+
+@overload
+def l_scale(
+    a: npt.ArrayLike,
+    /,
+    trim: AnyTrim = ...,
+    *,
+    axis: int,
+    dtype: np.dtype[T] | type[T],
+    **kwargs: Unpack[LMomentOptions],
+) -> npt.NDArray[T] | T:
+    ...
+
+
 def l_scale(
     a: npt.ArrayLike,
     /,
@@ -756,6 +860,58 @@ def l_scale(
         - [`numpy.std`][numpy.std]
     """
     return l_moment(a, 2, trim, axis=axis, dtype=dtype, **kwargs)
+
+
+@overload
+def l_variation(
+    a: npt.ArrayLike,
+    /,
+    trim: AnyTrim = ...,
+    *,
+    axis: None = ...,
+    dtype: type[np.float64] = ...,
+    **kwargs: Unpack[LMomentOptions],
+) -> np.float64:
+    ...
+
+
+@overload
+def l_variation(
+    a: npt.ArrayLike,
+    /,
+    trim: AnyTrim = ...,
+    *,
+    axis: None = ...,
+    dtype: np.dtype[T] | type[T],
+    **kwargs: Unpack[LMomentOptions],
+) -> T:
+    ...
+
+
+@overload
+def l_variation(
+    a: npt.ArrayLike,
+    /,
+    trim: AnyTrim = ...,
+    *,
+    axis: int,
+    dtype: type[np.float64] = ...,
+    **kwargs: Unpack[LMomentOptions],
+) -> npt.NDArray[np.float64] | np.float64:
+    ...
+
+
+@overload
+def l_variation(
+    a: npt.ArrayLike,
+    /,
+    trim: AnyTrim = ...,
+    *,
+    axis: int,
+    dtype: np.dtype[T] | type[T],
+    **kwargs: Unpack[LMomentOptions],
+) -> npt.NDArray[T] | T:
+    ...
 
 
 def l_variation(
@@ -804,6 +960,58 @@ def l_variation(
     return l_ratio(a, 2, 1, trim, axis=axis, dtype=dtype, **kwargs)
 
 
+@overload
+def l_skew(
+    a: npt.ArrayLike,
+    /,
+    trim: AnyTrim = ...,
+    *,
+    axis: None = ...,
+    dtype: type[np.float64] = ...,
+    **kwargs: Unpack[LMomentOptions],
+) -> np.float64:
+    ...
+
+
+@overload
+def l_skew(
+    a: npt.ArrayLike,
+    /,
+    trim: AnyTrim = ...,
+    *,
+    axis: None = ...,
+    dtype: np.dtype[T] | type[T],
+    **kwargs: Unpack[LMomentOptions],
+) -> T:
+    ...
+
+
+@overload
+def l_skew(
+    a: npt.ArrayLike,
+    /,
+    trim: AnyTrim = ...,
+    *,
+    axis: int,
+    dtype: type[np.float64] = ...,
+    **kwargs: Unpack[LMomentOptions],
+) -> npt.NDArray[np.float64] | np.float64:
+    ...
+
+
+@overload
+def l_skew(
+    a: npt.ArrayLike,
+    /,
+    trim: AnyTrim = ...,
+    *,
+    axis: int,
+    dtype: np.dtype[T] | type[T],
+    **kwargs: Unpack[LMomentOptions],
+) -> npt.NDArray[T] | T:
+    ...
+
+
 def l_skew(
     a: npt.ArrayLike,
     /,
@@ -841,6 +1049,58 @@ def l_skew(
         - [`scipy.stats.skew`][scipy.stats.skew]
     """  # noqa: D415
     return l_ratio(a, 3, 2, trim, axis=axis, dtype=dtype, **kwargs)
+
+
+@overload
+def l_kurtosis(
+    a: npt.ArrayLike,
+    /,
+    trim: AnyTrim = ...,
+    *,
+    axis: None = ...,
+    dtype: type[np.float64] = ...,
+    **kwargs: Unpack[LMomentOptions],
+) -> np.float64:
+    ...
+
+
+@overload
+def l_kurtosis(
+    a: npt.ArrayLike,
+    /,
+    trim: AnyTrim = ...,
+    *,
+    axis: None = ...,
+    dtype: np.dtype[T] | type[T],
+    **kwargs: Unpack[LMomentOptions],
+) -> T:
+    ...
+
+
+@overload
+def l_kurtosis(
+    a: npt.ArrayLike,
+    /,
+    trim: AnyTrim = ...,
+    *,
+    axis: int,
+    dtype: type[np.float64] = ...,
+    **kwargs: Unpack[LMomentOptions],
+) -> npt.NDArray[np.float64] | np.float64:
+    ...
+
+
+@overload
+def l_kurtosis(
+    a: npt.ArrayLike,
+    /,
+    trim: AnyTrim = ...,
+    *,
+    axis: int,
+    dtype: np.dtype[T] | type[T],
+    **kwargs: Unpack[LMomentOptions],
+) -> npt.NDArray[T] | T:
+    ...
 
 
 def l_kurtosis(

--- a/tests/test_univariate.py
+++ b/tests/test_univariate.py
@@ -94,7 +94,7 @@ def test_l_loc_mean(a: npt.NDArray[Any]):
 @given(a=st_a2)
 def test_l_loc_mean_2d(a: npt.NDArray[Any]):
     locs = a.mean(axis=0, dtype=np.float64)
-    l_locs = lmo.l_loc(a, axis=0)
+    l_locs = cast(npt.NDArray[np.float64], lmo.l_loc(a, axis=0))
 
     assert len(l_locs) == a.shape[1]
     assert l_locs.shape == locs.shape
@@ -136,10 +136,10 @@ def test_l_loc_linearity(
     assert np.isscalar(l1)
 
     l1_add = lmo.l_loc(x + dloc, trim)
-    assert l1_add == approx(l1 + dloc, rel=1e-5, abs=1e-8)
+    assert l1_add == approx(l1 + dloc, rel=1e-5, abs=1e-8)  # type: ignore
 
     l1_mul = lmo.l_loc(x * dscale, trim)
-    assert l1_mul == approx(l1 * dscale, rel=1e-5, abs=1e-8)
+    assert l1_mul == approx(l1 * dscale, rel=1e-5, abs=1e-8)  # type: ignore
 
 
 @given(a=st_a1)
@@ -175,7 +175,7 @@ def test_l_scale_invariant_loc(
     l2 = lmo.l_scale(x, trim)
     assert np.isfinite(l2)
     assert np.isscalar(l2)
-    assert round(l2, 8) >= 0
+    assert round(l2, 8) >= 0  # type: ignore
 
     l2_add = lmo.l_scale(x + dloc, trim)
     assert l2_add == approx(l2, rel=1e-5, abs=1e-8)
@@ -194,13 +194,13 @@ def test_l_scale_linear_scale(
     l2 = lmo.l_scale(x, trim)
     assert np.isfinite(l2)
     assert np.isscalar(l2)
-    assert round(l2, 8) >= 0
+    assert round(l2, 8) >= 0  # type: ignore
 
     # asymmetric trimming flips under sign change
     itrim = trim[::-1] if dscale < 0 else trim
 
     l2_mul = lmo.l_scale(x * dscale, itrim)
-    assert l2_mul == approx(np.abs(l2 * dscale), abs=1e-8)
+    assert l2_mul == approx(abs(l2 * dscale), abs=1e-8)  # type: ignore
 
 
 def test_ll_trim_ev():


### PR DESCRIPTION
This affects:

- `lmo.l_loc`
- `lmo.l_scale`
- `lmo.l_variation`
- `lmo.l_skew`
- `lmo.l_kurtosis`

fixes #74