### PR TITLE
Entropy of the Wakeby distribution

### DIFF
--- a/lmo/distributions.py
+++ b/lmo/distributions.py
@@ -865,6 +865,29 @@ class wakeby_gen(_rv_continuous):  # noqa: N801
             cast(_ArrF8, _wakeby_lmo(r, s, t, b, d, f)),
         )
 
+    def _entropy(self, b: float, d: float, f: float) -> float:
+        """
+        Entropy can be calculated from the QDF (PPF derivative) as the
+        Integrate[Log[QDF[u]], {u, 0, 1}]. This is the (semi) closed-form
+        solution in this case.
+        At the time of writing, this result appears to be novel.
+
+        The `f` conditionals are the limiting cases, e.g. for uniform,
+        exponential, and GPD (genpareto).
+        """
+        if f == 0:
+            return 1 + d
+        if f == 1:
+            return 1 - b
+
+        bd = b + d
+        assert bd > 0
+
+        return 1 - b + bd * cast(
+            float,
+            sc.hyp2f1(1, 1 / bd, 1 + 1 / bd, -f / (1 - f)),  # type: ignore
+        )
+
 
 wakeby: RVContinuous[float, float, float] = wakeby_gen(
     a=0.0,


### PR DESCRIPTION
I managed to derive the entropy of the Wakeby distribution, specifically:

$$
1 - \beta + (\beta + \delta) \ {}_2 \mathrm{F}_1(1, 1 / (\beta + \delta); 1+1 / (\beta + \delta); -\phi / (1 - \phi))
$$

Note that when $\phi \in \\{0, 1\\}$, this should be evaluated in the limit, yielding $1 + \delta$ or $1 - \beta$, respectively.

---

This is now implemented in `lmo.distributions.wakeby.entropy`, which significantly increases its performance.