### PR TITLE
Cleaner & faster doctests

### DIFF
--- a/lmo/_poly.py
+++ b/lmo/_poly.py
@@ -266,9 +266,9 @@ def extrema_jacobi(n: int, a: float, b: float) -> tuple[float, float]:
         >>> extrema_jacobi(3, 0, 3)
         (-20.0, 1.0)
         >>> extrema_jacobi(3, 0, 4)
-        (-35.0, 1.13541...)
+        (-35.0, 1.13541)
         >>> extrema_jacobi(3, 0, 5)
-        (-56.0, 1.25241...)
+        (-56.0, 1.25241)
 
         Looking at the corresponding \( x \) can help to understand the
         "movement" of the maximum.
@@ -278,9 +278,9 @@ def extrema_jacobi(n: int, a: float, b: float) -> tuple[float, float]:
         >>> arg_extrema_jacobi(3, 0, 3)
         (-1.0, 0.0)
         >>> arg_extrema_jacobi(3, 0, 4)
-        (-1.0, 0.09449...)
+        (-1.0, 0.094495)
         >>> arg_extrema_jacobi(3, 0, 5)
-        (-1.0, 0.17287...)
+        (-1.0, 0.172874)
 
     """
     x = peaks_jacobi(n, a, b)
@@ -290,7 +290,7 @@ def extrema_jacobi(n: int, a: float, b: float) -> tuple[float, float]:
 
 def _jacobi_coefs(n: int, a: float, b: float) -> npt.NDArray[np.float64]:
     p_n: np.poly1d
-    p_n = scs.jacobi(n, a, b)  # type: ignore [reportUnknownMemberType]
+    p_n = scs.jacobi(n, a, b)  # pyright: ignore[reportUnknownMemberType]
     return p_n.coef[::-1]
 
 
@@ -332,9 +332,6 @@ def jacobi_series(
         msg = 'coefs must be 1-D'
         raise ValueError(msg)
 
-    # if a == b == 0:
-    #     p = npp.Legendre(w, symbol=symbol, **kwargs)
-    # else:
     n = len(w)
     p = cast(
         PolySeries,

--- a/lmo/contrib/scipy_stats.py
+++ b/lmo/contrib/scipy_stats.py
@@ -261,7 +261,7 @@ class l_rv_generic(PatchClass):
             >>> norm(100, 15).l_moment([1, 2, 3, 4]).round(6)
             array([100.      ,   8.462844,   0.      ,   1.037559])
             >>> _[1] * np.sqrt(np.pi)
-            15.000000...
+            15.0000004
 
             Discrete distributions are also supported, e.g. the Binomial
             distribution:
@@ -392,22 +392,22 @@ class l_rv_generic(PatchClass):
             >>> from scipy.stats import distributions
             >>> X = distributions.rayleigh()
             >>> X.std() / X.mean()  # legacy CV
-            0.5227232...
+            0.5227232
             >>> X.l_ratio(2, 1)
-            0.2928932...
+            0.2928932
             >>> X.l_ratio(2, 1, trim=(0, 1))
-            0.2752551...
+            0.2752551
 
             And similarly, for the (discrete) Poisson distribution with rate
             parameter set to 2, the L-CF and LL-CV evaluate to:
 
             >>> X = distributions.poisson(2)
             >>> X.std() / X.mean()
-            0.7071067...
+            0.7071067
             >>> X.l_ratio(2, 1)
-            0.3857527...
+            0.3857527
             >>> X.l_ratio(2, 1, trim=(0, 1))
-            0.4097538...
+            0.4097538
 
             Note that (untrimmed) L-CV requires a higher (subdivision) limit in
             the integration routine, otherwise it'll complain that it didn't
@@ -1135,24 +1135,24 @@ class l_rv_generic(PatchClass):
             >>> rng = np.random.default_rng(12345)
             >>> x = rng.standard_normal(200)
             >>> norm.fit(x)
-            (0.0033..., 0.9555...)
+            (0.0033254, 0.95554)
 
             Better results can be obtained different by using Lmo's L-MM
             (Method of L-moment):
 
             >>> norm.l_fit(x, random_state=rng)
-            FitArgs(loc=0.0033..., scale=0.9617...)
+            FitArgs(loc=0.0033145, scale=0.96179)
             >>> norm.l_fit(x, trim=1, random_state=rng)
-            FitArgs(loc=0.0197..., scale=0.9674...)
+            FitArgs(loc=0.019765, scale=0.96749)
 
             To use more L-moments than the number of parameters, two in this
             case, `n_extra` can be used. This will use the L-GMM (Generalized
             Method of L-Moments), which results in slightly better estimates:
 
             >>> norm.l_fit(x, n_extra=1, random_state=rng)
-            FitArgs(loc=0.0039..., scale=0.9623...)
+            FitArgs(loc=0.0039747, scale=0.96233)
             >>> norm.l_fit(x, trim=1, n_extra=1, random_state=rng)
-            FitArgs(loc=-0.0012..., scale=0.9685...)
+            FitArgs(loc=-0.00127874, scale=0.968547)
 
         Parameters:
             data:

--- a/lmo/diagnostic.py
+++ b/lmo/diagnostic.py
@@ -120,9 +120,9 @@ def normaltest(
         >>> n = 10_000
         >>> x = 0.9 * rng.normal(0, 1, n) + 0.1 * rng.normal(0, 9, n)
         >>> normaltest(x)[1]
-        0.04806618...
+        0.04806618
         >>> normaltest_scipy(x)[1]
-        0.08435627...
+        0.08435627
 
         At a 5% significance level, Lmo's test is significant (i.e. indicating
         non-normality), whereas scipy's test isn't (i.e. inconclusive).
@@ -240,16 +240,16 @@ def l_moment_gof(
         >>> x = X.rvs(n, random_state=rng)
         >>> x_lm = lmo.l_moment(x, [1, 2, 3, 4])
         >>> l_moment_gof(X, x_lm, n).pvalue
-        0.8259...
+        0.82597
 
         Contaminated samples:
 
         >>> y = 0.9 * x + 0.1 * rng.normal(X.mean(), X.std() * 10, n)
-        >>> y_lm = lmo.l_moment(y, [1,2,3,4])
+        >>> y_lm = lmo.l_moment(y, [1, 2, 3, 4])
         >>> y_lm.round(3)
-        array([1.3193e+01, 1.2860e+00, 6.0000e-03, 1.6800e-01])
+        array([13.193, 1.286, 0.006, 0.168])
         >>> l_moment_gof(X, y_lm, n).pvalue
-        1.2668...e-60
+        0.0
 
 
     See Also:
@@ -560,7 +560,7 @@ def l_ratio_bounds(
         >>> l_ratio_bounds(3, trim=(0, 3))
         (-0.8, 2.0)
         >>> l_ratio_bounds(4, trim=(0, 3))
-        (-0.2333..., 3.5)
+        (-0.233333, 3.5)
 
         The LH-skewness bounds are "flipped" w.r.t to the LL-skewness,
         but they are the same for the L*-kurtosis:
@@ -568,12 +568,12 @@ def l_ratio_bounds(
         >>> l_ratio_bounds(3, trim=(3, 0))
         (-2.0, 0.8)
         >>> l_ratio_bounds(4, trim=(3, 0))
-        (-0.2333..., 3.5)
+        (-0.233333, 3.5)
 
         The bounds of multiple L-ratio's can be calculated in one shot:
-        >>> l_ratio_bounds([3, 4, 5, 6], trim=(1, 2))
-        (array([-1.        , -0.194..., -1.12      , -0.149...]),
-         array([1.333..., 1.75      , 2.24      , 2.8       ]))
+        >>> np.stack(l_ratio_bounds([3, 4, 5, 6], trim=(1, 2)))
+        array([[-1.        , -0.19444444, -1.12      , -0.14945848],
+               [ 1.33333333,  1.75      ,  2.24      ,  2.8       ]])
 
 
     Args:
@@ -684,11 +684,11 @@ def rejection_point(
         Student's t distribution with 4 degrees of freedom (3 also works, but
         is very slow), they exist.
 
-        >>> if_tl_loc_norm = dists.norm.l_moment_influence(1, trim=1)
-        >>> if_tl_loc_t4 = dists.t(4).l_moment_influence(1, trim=1)
-        >>> if_tl_loc_norm(np.inf), if_tl_loc_t4(np.inf)
+        >>> influence_norm = dists.norm.l_moment_influence(1, trim=1)
+        >>> influence_t4 = dists.t(4).l_moment_influence(1, trim=1)
+        >>> influence_norm(np.inf), influence_t4(np.inf)
         (0.0, 0.0)
-        >>> rejection_point(if_tl_loc_norm), rejection_point(if_tl_loc_t4)
+        >>> rejection_point(influence_norm), rejection_point(influence_t4)
         (6.0, 206.0)
 
     Notes:
@@ -772,9 +772,9 @@ def error_sensitivity(
         >>> ll_skew_if = expon.l_ratio_influence(3, 2, trim=(0, 1))
         >>> ll_kurt_if = expon.l_ratio_influence(4, 2, trim=(0, 1))
         >>> error_sensitivity(ll_skew_if, domain=(0, float('inf')))
-        1.814657...
+        1.814657
         >>> error_sensitivity(ll_kurt_if, domain=(0, float('inf')))
-        1.377743...
+        1.377743
 
     Args:
         influence_fn: Univariate influence function.
@@ -848,16 +848,16 @@ def shift_sensitivity(
         >>> ll_kurt_if = expon.l_ratio_influence(4, 2, trim=(0, 1))
         >>> domain = 0, float('inf')
         >>> shift_sensitivity(ll_skew_if, domain)
-        0.837735...
+        0.837735
         >>> shift_sensitivity(ll_kurt_if, domain)
-        1.442062...
+        1.442062
 
         Let's compare these with the untrimmed ones:
 
         >>> shift_sensitivity(expon.l_ratio_influence(3, 2), domain)
-        1.920317...
+        1.920317
         >>> shift_sensitivity(expon.l_ratio_influence(4, 2), domain)
-        1.047565...
+        1.047565
 
     Args:
         influence_fn: Univariate influence function.

--- a/lmo/special.py
+++ b/lmo/special.py
@@ -153,8 +153,8 @@ def gamma2(
 def harmonic(
     n: npt.ArrayLike,
     /,
-    out: npt.NDArray[np.float64] | npt.NDArray[np.complex128] | None = None,
-) -> float | complex | npt.NDArray[np.float64] | npt.NDArray[np.complex128]:
+    out: npt.NDArray[np.float64 | np.complex128] | None = None,
+) -> float | complex | npt.NDArray[np.float64 | np.complex128]:
     r"""
     Harmonic number \( H_n = \sum_{k=1}^{n} 1 / k \), extended for real and
     complex argument via analytic contunuation.
@@ -167,12 +167,12 @@ def harmonic(
         >>> harmonic(2)
         1.5
         >>> harmonic(42)
-        4.3267...
+        4.32674
         >>> harmonic(np.pi)
-        1.8727...
+        1.87274
         >>> harmonic(-1 / 12)
-        -0.1461...
-        >>> harmonic(1 - 1j)
+        -0.146106
+        >>> harmonic(1 - 1j)  # doctest: -FLOAT_CMP, +ELLIPSIS
         (1.1718...-0.5766...j)
 
     Args:
@@ -183,8 +183,7 @@ def harmonic(
         out: Array or scalar with the value(s) of the function.
 
     See Also:
-        - [Harmonic number - Wikipedia
-        ](https://wikipedia.org/wiki/Harmonic_number)
+        - [Harmonic number - Wikipedia](https://w.wiki/A63b)
     """
     _n = np.asanyarray(n)
 

--- a/lmo/theoretical.py
+++ b/lmo/theoretical.py
@@ -434,14 +434,14 @@ def l_moment_from_ppf(
         (even if `quad` returned a finite result).
 
     Examples:
-        Evaluate the first 4 L- and TL-moments of the standard normal
+        Evaluate the L- and TL-location and -scale of the standard normal
         distribution:
 
         >>> from scipy.special import ndtri  # standard normal inverse CDF
-        >>> l_moment_from_ppf(ndtri, [1, 2, 3, 4])
-        array([0.        , 0.56418958, 0.        , 0.06917061])
-        >>> l_moment_from_ppf(ndtri, [1, 2, 3, 4], trim=1)
-        array([0.        , 0.29701138, 0.        , 0.01855727])
+        >>> l_moment_from_ppf(ndtri, [1, 2])
+        array([0.        , 0.56418958])
+        >>> l_moment_from_ppf(ndtri, [1, 2], trim=1)
+        array([0.        , 0.29701138])
 
     Args:
         ppf:
@@ -1464,33 +1464,37 @@ def l_comoment_from_pdf(
         Find the L-coscale and TL-coscale matrices of the multivariate
         Student's t distribution with 4 degrees of freedom:
 
-        >>> from lmo.theoretical import l_comoment_from_pdf
-        >>> from scipy.stats import multivariate_t, t
+        >>> from scipy.stats import multivariate_t
         >>> df = 4
         >>> loc = np.array([0.5, -0.2])
         >>> cov = np.array([[2.0, 0.3], [0.3, 0.5]])
-        >>> X = multivariate_t(loc, cov, df)
-        >>> cdfs = [t(df, loc[i], np.sqrt(cov[i, i])).cdf for i in range(2)]
-        >>> l_cov = l_comoment_from_pdf(X.pdf, cdfs, 2)
+        >>> X = multivariate_t(loc=loc, shape=cov, df=df)
+
+        >>> from scipy.special import stdtr
+        >>> std = np.sqrt(np.diag(cov))
+        >>> cdf0 = lambda x: stdtr(df, (x - loc[0]) / std[0])
+        >>> cdf1 = lambda x: stdtr(df, (x - loc[1]) / std[1])
+
+        >>> l_cov = l_comoment_from_pdf(X.pdf, (cdf0, cdf1), 2)
         >>> l_cov.round(4)
         array([[1.0413, 0.3124],
                [0.1562, 0.5207]])
-        >>> tl_cov = l_comoment_from_pdf(X.pdf, cdfs, 2, trim=1)
+        >>> tl_cov = l_comoment_from_pdf(X.pdf, (cdf0, cdf1), 2, trim=1)
         >>> tl_cov.round(4)
         array([[0.4893, 0.1468],
                [0.0734, 0.2447]])
 
-        The correlation coefficient can be recovered in several ways:
+        The (Pearson) correlation coefficient can be recovered in several ways:
 
         >>> cov[0, 1] / np.sqrt(cov[0, 0] * cov[1, 1])  # "true" correlation
         0.3
-        >>> np.round(l_cov[0, 1] / l_cov[0, 0], 4)
+        >>> l_cov[0, 1] / l_cov[0, 0]
         0.3
-        >>> np.round(l_cov[1, 0] / l_cov[1, 1], 4)
+        >>> l_cov[1, 0] / l_cov[1, 1]
         0.3
-        >>> np.round(tl_cov[0, 1] / tl_cov[0, 0], 4)
+        >>> tl_cov[0, 1] / tl_cov[0, 0]
         0.3
-        >>> np.round(tl_cov[1, 0] / tl_cov[1, 1], 4)
+        >>> tl_cov[1, 0] / tl_cov[1, 1]
         0.3
 
     Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,12 +101,11 @@ addopts = [
 ]
 doctest_optionflags = [
     "NORMALIZE_WHITESPACE",
-    "IGNORE_EXCEPTION_DETAIL",
     "ELLIPSIS",
-    # "FLOAT_CMP",
+    "FLOAT_CMP",
 ]
 doctest_plus = "enabled"
-doctest_subpackage_requires = {"lmo/contrib/pandas.py" = "pandas>=1.4"}
+doctest_subpackage_requires = {"lmo/contrib/pandas.py" = "pandas>=1.5"}
 filterwarnings = ["error"]
 log_cli_level = "INFO"
 testpaths = ["tests", "lmo"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,6 @@ addopts = [
 ]
 doctest_optionflags = [
     "NORMALIZE_WHITESPACE",
-    "ELLIPSIS",
     "FLOAT_CMP",
 ]
 doctest_plus = "enabled"


### PR DESCRIPTION
- Remove the `+ELLIPSIS` workarounds when comparing rounded floats, by using `FLOAT_CMP` from [pytest-doctestplus](https://github.com/scientific-python/pytest-doctestplus) instead.
- Improved `lmo.l_loc`  docs and examples, and mention that the trimmed L-location generalized not only the mean, but also unifies it with the median, minimum and maximum (which hasn't been pointed out in the literature before, to my knowledge)
- Significant speedup of the `theoretical.l_comoment_from_pdf` doctest, by replacing the marginal CDF `scipy.stats.t.cdf` with `scipy.special.stdtr`, so that it isn't a major CI performance bottleneck anymore.
- Fall back to the order-statistics method for weight calculation if $r+s+t>24$, avoiding (explosive) numerical errors with large moment- or trim- orders (e.g. when using trimmed L-loc for median, min or max).