### PR TITLE
Optional sorting

### DIFF
--- a/lmo/_lm_co.py
+++ b/lmo/_lm_co.py
@@ -118,7 +118,7 @@ def l_comoment(
             Floating type to use in computing the L-moments. Default is
             [`numpy.float64`][numpy.float64].
 
-        sort ('quick' | 'stable' | 'heap'):
+        sort ('quicksort' | 'heapsort' | 'stable'):
             Sorting algorithm, see [`numpy.sort`][numpy.sort].
         cache:
             Set to `True` to speed up future L-moment calculations that have
@@ -195,7 +195,7 @@ def l_comoment(
 
     for j in range(m):
         # *concomitants* of x[i] w.r.t. x[j] for all i
-        x_kij = ordered(x, x[j], axis=-1, sort=sort)
+        x_kij = ordered(x, x[j], axis=-1, sort=sort or True)
         l_kij[:, :, j] = np.inner(p_k, x_kij)
 
     if r_min == 0:

--- a/lmo/typing/_core.py
+++ b/lmo/typing/_core.py
@@ -22,7 +22,7 @@ class LMomentOptions(TypedDict, total=False):
     Use as e.g. `**kwds: Unpack[LMomentOptions]` (on `python<3.11`) or
     `**kwds: *LMomentOptions` (on `python>=3.11`).
     """
-    sort: lnpt.SortKind
+    sort: lnpt.SortKind | bool
     cache: bool
     fweights: AnyFWeights
     aweights: AnyAWeights


### PR DESCRIPTION
The `sort` kwarg in the univariate `lmo.l_*` can now be set to `False`. 