### PR TITLE
Enable caching by default for small orders

### DIFF
--- a/lmo/_lm.py
+++ b/lmo/_lm.py
@@ -65,12 +65,16 @@ _DType: TypeAlias = np.dtype[_T_float] | type[_T_float]
 _Vectorized: TypeAlias = _T_float | npt.NDArray[_T_float]
 _Floating: TypeAlias = np.floating[Any]
 
-# (n, s, t)
-_CacheKey: TypeAlias = tuple[int, int, int] | tuple[int, float, float]
+# (dtype.char, n, s, t)
+_CacheKey: TypeAlias = (
+    tuple[str, int, int, int]
+    | tuple[str, int, float, float]
+)
 # `r: _T_order >= 4`
 _CacheArray: TypeAlias = lnpt.Array[tuple[_T_order, _T_size], np.longdouble]
 _Cache: TypeAlias = dict[_CacheKey, _CacheArray[Any, Any]]
 
+# depends on `dtype`, `n`, and `trim`
 _CACHE: Final[_Cache] = {}
 
 
@@ -86,17 +90,19 @@ def _l_weights_pwm(
     r0 = r + s + t
 
     # `__matmul__` annotations are lacking (`np.matmul` is equivalent to it)
-    w0 = np.matmul(
+    wr = np.matmul(
         sh_legendre(r0, dtype=np.int64 if r0 < 29 else dtype),
         pwm_beta.weights(r0, n, dtype=dtype),
+        dtype=dtype,
     )
-    wr = np.matmul(trim_matrix(r, trim, dtype=dtype), w0) if s or t else w0
+    if s or t:
+        wr = np.matmul(trim_matrix(r, trim, dtype=dtype), wr, dtype=dtype)
 
-    # ensure that the trimmed ends are 0
-    if s:
-        wr[:, :s] = 0
-    if t:
-        wr[:, -t:] = 0
+        # ensure that the trimmed ends are 0
+        if s:
+            wr[:, :s] = 0
+        if t:
+            wr[:, -t:] = 0
 
     return wr
 
@@ -205,8 +211,11 @@ def l_weights(
         msg = f'r must be non-negative, got {r_max}'
         raise ValueError(msg)
 
+    dtype = np.dtype(dtype)
+    sctype = dtype.type
+
     if r_max == 0:
-        return np.empty((0, n), dtype=dtype)
+        return np.empty((0, n), dtype=sctype)
 
     s, t = clean_trim(trim)
 
@@ -214,25 +223,19 @@ def l_weights(
         msg = f'expected n >= r + s + t, got {n} < {n_min}'
         raise ValueError(msg)
 
-    # manual cache lookup, only if cache=False (for testability)
-    # e.g. `functools.cache` would be inefficient for e.g. r=3 with cached r=4
-    key = n, s, t
-    if (w := _CACHE.get(key)) is not None and w.shape[0] >= r_max:
-        pass
+    key = dtype.char, n, s, t
+    if (_w := _CACHE.get(key)) is not None and _w.shape[0] >= r_max:
+        w = cast(lnpt.Array[tuple[_T_order, _T_size], _T_float], _w)
     else:
         # when caching, use at least 4 orders, to avoid cache misses
         _r_max = 4 if cache and r_max < 4 else r_max
 
-        # use the highest available precision when caching (96 or 128 bits,
-        # depending on the platform)
-        _dtype = np.longdouble if cache else dtype
-
         _cache_default = False
         if r_max + s + t <= 24 and isinstance(s, int) and isinstance(t, int):
-            w = _l_weights_pwm(_r_max, n, trim=(s, t), dtype=_dtype)
+            w = _l_weights_pwm(_r_max, n, trim=(s, t), dtype=sctype)
             _cache_default = True
         else:
-            w = _l_weights_ostat(_r_max, n, trim=(s, t), dtype=_dtype)
+            w = _l_weights_ostat(_r_max, n, trim=(s, t), dtype=sctype)
 
         if cache or cache is None and _cache_default:
             w.setflags(write=False)
@@ -242,8 +245,7 @@ def l_weights(
 
     if w.shape[0] > r_max:
         w = w[:r_max]
-
-    return w.astype(dtype, casting='same_kind', copy=False)
+    return w
 
 
 @overload

--- a/lmo/_lm_co.py
+++ b/lmo/_lm_co.py
@@ -50,7 +50,7 @@ def l_comoment(
     dtype: _DType[_T_float] = np.float64,
     rowvar: bool | None = None,
     sort: lnpt.SortKind | None = None,
-    cache: bool = False,
+    cache: bool | None = None,
 ) -> lnpt.Array[Any, _T_float]:
     r"""
     Multivariate extension of [`lmo.l_moment`][lmo.l_moment].
@@ -123,7 +123,8 @@ def l_comoment(
         cache:
             Set to `True` to speed up future L-moment calculations that have
             the same number of observations in `a`, equal `trim`, and equal or
-            smaller `r`.
+            smaller `r`. By default, it will cache i.f.f. the trim is integral,
+            and $r + s + t \le 24$. Set to `False` to always disable caching.
 
     Returns:
         L: Array of shape `(*r.shape, m, m)` with r-th L-comoments.

--- a/lmo/typing/_core.py
+++ b/lmo/typing/_core.py
@@ -23,7 +23,7 @@ class LMomentOptions(TypedDict, total=False):
     `**kwds: *LMomentOptions` (on `python>=3.11`).
     """
     sort: lnpt.SortKind | bool
-    cache: bool
+    cache: bool | None
     fweights: AnyFWeights
     aweights: AnyAWeights
 
@@ -34,5 +34,5 @@ class LComomentOptions(TypedDict, total=False):
     `**kwds: *LComomentOptions` (on `python>=3.11`).
     """
     sort: lnpt.SortKind
-    cache: bool
+    cache: bool | None
     rowvar: bool | None

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -42,26 +42,26 @@ st_i12_eq0 = st_i_eq0 | st_i2_eq0
 st_i12_ge0 = st_i_ge0 | st_i2_ge0
 st_i12_gt0 = st_i_gt0 | st_i2_gt0
 
-st_floating = hnp.floating_dtypes()
+st_floating = hnp.floating_dtypes(sizes=[32, 64])
 
 
 @given(n=st_n, trim=st_i12_eq0)
 def test_empty(n: int, trim: int | tuple[int, int]):
-    w = l_weights(0, n, trim)
+    w = l_weights(0, n, trim, cache=False)
     assert w.shape == (0, n)
 
 
 @given(n=st_n, r=st_r, trim=st_i12_eq0)
 def test_untrimmed(n: int, r: int, trim: int | tuple[int, int]):
-    w_l = l_weights(r, n)
-    w_tl = l_weights(r, n, trim)
+    w_l = l_weights(r, n, cache=False)
+    w_tl = l_weights(r, n, trim, cache=False)
 
     assert_array_equal(w_l, w_tl)
 
 
 @given(n=st_n, r=st_r, trim=st_i12_ge0)
 def test_default(n: int, r: int, trim: int | tuple[int, int]):
-    w = l_weights(r, n, trim)
+    w = l_weights(r, n, trim, cache=False)
 
     assert w.shape == (r, n)
     assert np.all(np.isfinite(w))
@@ -75,7 +75,7 @@ def test_dtype(
     trim: int | tuple[int, int],
     dtype: np.dtype[np.floating[Any]],
 ):
-    w = l_weights(r, n, trim, dtype=dtype)
+    w = l_weights(r, n, trim, dtype=dtype, cache=False)
 
     assert np.all(np.isfinite(w))
     assert w.dtype.type is dtype.type
@@ -83,7 +83,7 @@ def test_dtype(
 
 @given(n=st_n, t=st_i_ge0)
 def test_symmetry(n: int, t: int):
-    w = l_weights(MAX_R, n, (t, t))
+    w = l_weights(MAX_R, n, (t, t), cache=False)
 
     w_evn_lhs, w_evn_rhs = w[::2], w[::2, ::-1]
     assert_allclose(w_evn_lhs, w_evn_rhs)
@@ -93,7 +93,7 @@ def test_symmetry(n: int, t: int):
 
 
 def test_l_weights_symmetry_large_even_r():
-    w = l_weights(16, MAX_N * 2)
+    w = l_weights(16, MAX_N * 2, cache=False)
 
     w_evn_lhs, w_evn_rhs = w[::2], w[::2, ::-1]
     assert_allclose(w_evn_lhs, w_evn_rhs)
@@ -101,7 +101,7 @@ def test_l_weights_symmetry_large_even_r():
 
 @given(n=st_n, r=st_r, trim=st_i2_gt0)
 def test_trim(n: int, r: int, trim: tuple[int, int]):
-    w = l_weights(r, n, trim)
+    w = l_weights(r, n, trim, cache=False)
 
     tl, tr = trim
     assert tl > 0
@@ -113,7 +113,7 @@ def test_trim(n: int, r: int, trim: tuple[int, int]):
 
 @given(n=st_n, r=st.integers(2, MAX_R), trim=st_i12_ge0)
 def test_sum(n: int, r: int, trim: int | tuple[int, int]):
-    w = l_weights(r, n, trim)
+    w = l_weights(r, n, trim, cache=False)
     w_sum = w.sum(axis=-1)
 
     assert_allclose(w_sum, np.eye(r, 1).ravel())
@@ -130,14 +130,22 @@ def test_uncached(n: int, r: int, trim: int | tuple[int, int]):
         assert_array_equal(w0, w1)
 
 
-@given(n=st_n, r=st.integers(4, MAX_R), trim=st_i12_ge0)
-def test_cached(n: int, r: int, trim: int | tuple[int, int]):
-    cache_key = (n, *trim) if isinstance(trim, tuple) else (n, trim, trim)
+@given(n=st_n, r=st.integers(4, MAX_R), trim=st_i12_ge0, dtype=st_floating)
+def test_cached(
+    n: int,
+    r: int,
+    trim: int | tuple[int, int],
+    dtype: np.dtype[np.floating[Any]],
+):
+    s, t = trim if isinstance(trim, tuple) else (trim, trim)
+    cache_key = dtype.char, n, s, t
 
     with tmp_cache() as cache:
-        assert cache_key not in cache
+        assert not cache
 
-        w0 = l_weights(r, n, trim, dtype=np.longdouble)
+        w0 = l_weights(r, n, trim, dtype=dtype, cache=True)
+        assert w0.dtype.char == cache_key[0]
+        assert cache
         assert cache_key in cache
         w0_cached = cache[cache_key]
 
@@ -150,9 +158,9 @@ def test_cached(n: int, r: int, trim: int | tuple[int, int]):
             w0[0, 0] = w0_orig + 1
         assert w0[0, 0] == w0_orig
 
-        w1 = l_weights(r, n, trim, cache=True, dtype=np.longdouble)
+        w1 = l_weights(r, n, trim, dtype=dtype, cache=True)
         w1_cached = cache[cache_key]
         assert w0_cached is w1_cached
 
-        # this requires `r>=4`, `dtype=np.longdouble` and `r == r_cached`
+        # this requires `r>=4` and `r == r_cached`
         assert w0 is w1

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -137,7 +137,7 @@ def test_cached(n: int, r: int, trim: int | tuple[int, int]):
     with tmp_cache() as cache:
         assert cache_key not in cache
 
-        w0 = l_weights(r, n, trim, cache=True, dtype=np.longdouble)
+        w0 = l_weights(r, n, trim, dtype=np.longdouble)
         assert cache_key in cache
         w0_cached = cache[cache_key]
 


### PR DESCRIPTION
This affects all sample estimators, i.e. `lmo.l_*` and most of `lmo.diagnostic`.

- If `cache=None` (default), the weights will be cached i.f.f. `r + sum(trim) <= 24`, and the trim-orders are integral. To always enable/disable it, use `cache=True` or `cache=False`.
- Additionally, the cache is now dtype-aware (added `np.dtype.char` to the cache key)