### PR TITLE
Docs: minor grammar and typo corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ So Lmo is as fast as sorting your samples (in terms of time-complexity).
 
 - Calculates trimmed L-moments and L-*co*moments, from samples or any
   `scipy.stats` distribution.
-- Full support for trimmed L-moment (TL-moments), e.g.
+- Full support for trimmed L-moments (TL-moments), e.g.
   `lmo.l_moment(..., trim=(1/137, 3.1416))`.
 - Generalized Method of L-moments: robust distribution fitting that beats MLE.
 - Fast estimation of L-*co*moment matrices from your multidimensional data
@@ -35,7 +35,7 @@ So Lmo is as fast as sorting your samples (in terms of time-complexity).
 reference with usage examples and with mathematical $\TeX$ definitions.
 - Clean Pythonic syntax for ease of use.
 - Vectorized functions for very fast fitting.
-- Fully typed, tested, and tickled.
+- Fully typed, tested, and validated.
 - Optional Pandas integration.
 
 ## Quick example
@@ -45,7 +45,7 @@ Even if your data is pathological like
 are not defined, the trimmed L-moments (TL-moments) can be used instead.
 
 Let's calculate the first two TL-moments (the TL-location and the TL-scale) of a small
-amount of samples drawn from the standard Cauchy distribution:
+number of samples drawn from the standard Cauchy distribution:
 
 ```pycon
 >>> import numpy as np

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ amount of samples drawn from the standard Cauchy distribution:
 array([-0.17937038,  0.68287665])
 ```
 
-Compared with the theoretical standard Cauchy TL-moments, that pretty close!
+Compared with the theoretical standard Cauchy TL-moments, that's pretty close!
 
 ```pycon
 >>> from scipy.stats import cauchy
@@ -74,7 +74,7 @@ array([-1.7113441 , 19.57350731])
 ```
 
 So even though the `data` was drawn from the *standard* Cauchy distribution, we can
-immediately see that this look standard at all.
+immediately see that this does not look standard at all.
 
 The reason is that the Cauchy distribution doesn't have a mean or standard
 deviation:


### PR DESCRIPTION
This PR corrects grammar, typos, and improves wording in the README to make the readability and maintain a professional tone.

Key Changes include:
- Fixed sentences such as "immediately see that this look standard at all" to "immediately see that this does not look standard at all".
- Replaced "Fully typed, tested, and tickled" to "Fully typed, tested, and validated".
- Changes "amount of samples" to "number of samples" .
- Corrected "Full support for trimmed L-moment" to "Full support for trimmed L-moments".
- Updated "Compared with the theoretical standard Cauchy TL-moments, that pretty close!" to "Compared with the theoretical standard Cauchy TL-moments, that's pretty close!".

No bugs or functional changes have been made, only documentation clarity and correctness.
